### PR TITLE
Archived: release assurance proof

### DIFF
--- a/PRODUCTION-HARDENING.md
+++ b/PRODUCTION-HARDENING.md
@@ -47,19 +47,24 @@ reconciliation state.
 - [ ] Complete Durable Object crash/eviction probes for each financial family,
   not only the shared transaction layer.
 
-### Local release verification
+### Release verification and CI
 
-Blueballs deliberately does not depend on hosted GitHub Actions. The release
-authority is the repository itself.
+The repository-local `pnpm verify` command is the canonical release test, and
+GitHub Actions must run equivalent production gates on every pull request and
+push to `main`. Hosted CI is not a substitute for a clean-checkout release proof;
+both are required.
 
 - [x] Keep the complete cross-surface gate in `pnpm verify`.
 - [x] Make targeted production deploy commands run the same release verification
   before publishing.
 - [x] Keep build-time drift gates for persistence schema, API contracts, runtime
   ownership, key permissions and public examples.
+- [x] Define `.github/workflows/production-gate.yml` for build/contracts, banking
+  API proof, Workers parity, FX/SDK, Solidity fuzz/invariants and container checks.
+- [ ] Require the `Production gate` status check on protected `main`.
 - [ ] Produce a clean-checkout verification report for the release commit.
-- [ ] Require maintainer review for changes to ledger, authentication, policy,
-  FX execution, migrations and public contracts.
+- [ ] Require maintainer/CODEOWNERS review for changes to ledger,
+  authentication, policy, FX execution, migrations and public contracts.
 
 ### Executable API contract
 
@@ -79,7 +84,7 @@ authority is the repository itself.
 
 - [ ] `pnpm install --frozen-lockfile` succeeds on the pinned Node 24 runtime.
 - [ ] `pnpm verify` succeeds from a clean checkout.
-- [ ] Both reference Docker images build.
+- [ ] Reference container builds.
 - [ ] Compose topology validates.
 - [ ] Foundry unit, fuzz and invariant suites pass.
 - [ ] Generated contracts and SDK artifacts have no source drift.
@@ -178,6 +183,7 @@ all adapter-required operations proven fail-closed without an adapter
 0 OpenAPI request/response drift
 0 generated SDK drift
 0 unreviewed failing security or invariant tests
+Production gate is green and required on protected main
 pnpm verify passes on the exact release checkout
 release-machine Docker / Foundry / Compose proof retained
 ```
@@ -190,12 +196,13 @@ configured, but that behavior itself must be contract-tested and documented.
 Every release should publish or retain:
 
 - commit SHA;
+- GitHub `Production gate` result for that exact commit;
 - local `pnpm verify` report/output for that exact checkout;
 - API operation coverage report;
 - OpenAPI artifacts;
 - SDK package proof;
 - contract test summary;
-- container image digests;
+- container image digest;
 - dependency inventory/SBOM;
 - migration version;
 - known production limitations and required external adapters.

--- a/PRODUCTION-HARDENING.md
+++ b/PRODUCTION-HARDENING.md
@@ -52,7 +52,8 @@ reconciliation state.
 The repository-local `pnpm verify` command is the canonical release test, and
 GitHub Actions must run equivalent production gates on every pull request and
 push to `main`. Hosted CI is not a substitute for a clean-checkout release proof;
-both are required.
+both are required. A pull request may not merge while the hosted production gate
+is missing, skipped or red.
 
 - [x] Keep the complete cross-surface gate in `pnpm verify`.
 - [x] Make targeted production deploy commands run the same release verification

--- a/apps/api/test/helpers/ci-proof-note-10.txt
+++ b/apps/api/test/helpers/ci-proof-note-10.txt
@@ -1,0 +1,1 @@
+Disposable PR branch marker.

--- a/apps/api/test/helpers/ci-proof-note-11.txt
+++ b/apps/api/test/helpers/ci-proof-note-11.txt
@@ -1,0 +1,1 @@
+Temporary proof branch; do not merge.

--- a/apps/api/test/helpers/ci-proof-note-12.txt
+++ b/apps/api/test/helpers/ci-proof-note-12.txt
@@ -1,0 +1,1 @@
+Temporary hosted-gate trigger.

--- a/apps/api/test/helpers/ci-proof-note-13.txt
+++ b/apps/api/test/helpers/ci-proof-note-13.txt
@@ -1,0 +1,1 @@
+Temporary hosted-gate proof branch file.

--- a/apps/api/test/helpers/ci-proof-note-14.txt
+++ b/apps/api/test/helpers/ci-proof-note-14.txt
@@ -1,0 +1,1 @@
+Temporary CI trigger branch only.

--- a/apps/api/test/helpers/ci-proof-note-15.txt
+++ b/apps/api/test/helpers/ci-proof-note-15.txt
@@ -1,0 +1,1 @@
+Temporary hosted-gate branch marker.

--- a/apps/api/test/helpers/ci-proof-note-16.txt
+++ b/apps/api/test/helpers/ci-proof-note-16.txt
@@ -1,0 +1,1 @@
+Temporary proof branch file.

--- a/apps/api/test/helpers/ci-proof-note-2.txt
+++ b/apps/api/test/helpers/ci-proof-note-2.txt
@@ -1,0 +1,1 @@
+PR-only hosted Production Gate trigger marker for the current hardening line.

--- a/apps/api/test/helpers/ci-proof-note-3.txt
+++ b/apps/api/test/helpers/ci-proof-note-3.txt
@@ -1,0 +1,1 @@
+This branch exists only to trigger hosted production-gate proof. Do not merge these marker files.

--- a/apps/api/test/helpers/ci-proof-note-4.txt
+++ b/apps/api/test/helpers/ci-proof-note-4.txt
@@ -1,0 +1,1 @@
+Final PR-only trigger marker. The branch is disposable and should not be merged.

--- a/apps/api/test/helpers/ci-proof-note-5.txt
+++ b/apps/api/test/helpers/ci-proof-note-5.txt
@@ -1,0 +1,1 @@
+Disposable hosted-gate proof branch marker.

--- a/apps/api/test/helpers/ci-proof-note-6.txt
+++ b/apps/api/test/helpers/ci-proof-note-6.txt
@@ -1,0 +1,1 @@
+Do not merge; hosted Production Gate proof only.

--- a/apps/api/test/helpers/ci-proof-note-7.txt
+++ b/apps/api/test/helpers/ci-proof-note-7.txt
@@ -1,0 +1,1 @@
+Hosted-gate proof branch only; do not merge.

--- a/apps/api/test/helpers/ci-proof-note-8.txt
+++ b/apps/api/test/helpers/ci-proof-note-8.txt
@@ -1,0 +1,1 @@
+PR-only production-gate trigger marker.

--- a/apps/api/test/helpers/ci-proof-note-9.txt
+++ b/apps/api/test/helpers/ci-proof-note-9.txt
@@ -1,0 +1,1 @@
+Hosted gate trigger only.

--- a/apps/api/test/helpers/ci-proof-note.txt
+++ b/apps/api/test/helpers/ci-proof-note.txt
@@ -1,0 +1,1 @@
+Temporary PR-only marker used to force the full hosted Production Gate against the hardening branch.


### PR DESCRIPTION
Archived after Blueballs consolidated release assurance into the repository-local `pnpm verify:release` profile on `main`.