### PR TITLE
Archived: release verification proof

### DIFF
--- a/.github/production-gate-trigger.txt
+++ b/.github/production-gate-trigger.txt
@@ -1,0 +1,2 @@
+Production gate trigger for the 2026-09-11 production-hardening proof branch.
+This file has no runtime effect and may be deleted after CI behavior is verified.


### PR DESCRIPTION
Archived after the release-assurance model moved to the reproducible repository-local `pnpm verify:release` profile on `main`.