### PR TITLE
Consolidate dependency maintenance policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    groups:
+      production-minor-patch:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development-minor-patch:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
Final repository-maintenance pass after the production runtime closeout.

- groups npm minor/patch updates into deliberate maintenance PRs;
- ignores major upgrades so React/Node/toolchain migrations stay intentional;
- leaves GitHub Actions outside the dependency-update model;
- replaces the stale parallel Dependabot queue with one controlled maintenance path.

This changes repository maintenance policy only; no runtime code is modified.