### PR TITLE
Keep Agents SDK minor upgrades intentional

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,6 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+      - dependency-name: "agents"
+        update-types:
+          - version-update:semver-minor


### PR DESCRIPTION
The Agents 0.22 line changes runtime/chat lifecycle behaviour. Blueballs will keep patch updates automated but treat Agents minor-version changes as intentional migration work with full repository verification.