### PR TITLE
Expand Blueballs build and discovery surfaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/design_partner.yml
+++ b/.github/ISSUE_TEMPLATE/design_partner.yml
@@ -1,0 +1,61 @@
+name: Design partner
+description: Explore a financial product, market or institution built on Blueballs.
+title: "[Design partner] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Build with Blueballs
+        Use this form when you want to explore a product or market with the Blueballs project.
+
+        This is a public GitHub issue. Do not include credentials, customer information, confidential commercial terms or other sensitive data.
+  - type: input
+    id: organisation
+    attributes:
+      label: Organisation or project
+      placeholder: Company, institution, startup or project name
+    validations:
+      required: true
+  - type: dropdown
+    id: stage
+    attributes:
+      label: Stage
+      options:
+        - Exploring a new product
+        - Prototype or sandbox
+        - Preparing for implementation
+        - Existing product or institution
+    validations:
+      required: true
+  - type: textarea
+    id: product
+    attributes:
+      label: What are you building?
+      description: Describe the product, users and financial experience you want to create.
+      placeholder: A multi-currency business account for...
+    validations:
+      required: true
+  - type: input
+    id: markets
+    attributes:
+      label: Markets and currencies
+      placeholder: Singapore, Malaysia · SGD, MYR, USD
+  - type: textarea
+    id: scope
+    attributes:
+      label: Where could Blueballs help?
+      description: Banking, ledger, cards, payments, stablecoin FX, provider architecture, settlement, sandbox or another surface.
+    validations:
+      required: true
+  - type: textarea
+    id: timing
+    attributes:
+      label: Target outcome and timing
+      placeholder: What would a useful first milestone look like?
+  - type: checkboxes
+    id: public
+    attributes:
+      label: Public issue acknowledgement
+      options:
+        - label: I have not included secrets, customer data or confidential information.
+          required: true

--- a/.github/ISSUE_TEMPLATE/implementation.yml
+++ b/.github/ISSUE_TEMPLATE/implementation.yml
@@ -1,0 +1,59 @@
+name: Implementation
+description: Talk about integrating, adapting, deploying or operating Blueballs for a real product.
+title: "[Implementation] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Implement Blueballs
+        Blueballs is MIT licensed and free to fork. Use this route when you want the project involved in architecture, integration, provider adapters, deployment or operating design.
+
+        This is a public GitHub issue. Do not include credentials, customer information, confidential commercial terms or other sensitive data.
+  - type: input
+    id: organisation
+    attributes:
+      label: Organisation or project
+      placeholder: Company, institution, startup or project name
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: What do you want to ship?
+      placeholder: Describe the product and the implementation outcome.
+    validations:
+      required: true
+  - type: checkboxes
+    id: surfaces
+    attributes:
+      label: Relevant Blueballs surfaces
+      options:
+        - label: Banking API and ledger
+        - label: Payments, accounts or cards
+        - label: Provider adapters and orchestration
+        - label: Stablecoin FX and treasury
+        - label: Settlement contracts
+        - label: Sandbox and product experience
+        - label: Deployment, operations or hardening
+  - type: input
+    id: providers
+    attributes:
+      label: Providers or infrastructure already selected
+      placeholder: Optional — only name non-confidential providers or platforms
+  - type: input
+    id: markets
+    attributes:
+      label: Target markets
+      placeholder: Countries, regions or corridors
+  - type: textarea
+    id: timing
+    attributes:
+      label: Milestone and timing
+      placeholder: What needs to be working, and when?
+  - type: checkboxes
+    id: public
+    attributes:
+      label: Public issue acknowledgement
+      options:
+        - label: I have not included secrets, customer data or confidential information.
+          required: true

--- a/.github/ISSUE_TEMPLATE/provider.yml
+++ b/.github/ISSUE_TEMPLATE/provider.yml
@@ -1,0 +1,63 @@
+name: Provider ecosystem
+description: Add, update or explore a provider listing, adapter or infrastructure connection.
+title: "[Provider] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Connect infrastructure to Blueballs
+        Use this form for provider-directory updates, adapter work, compatibility discussions or infrastructure collaboration.
+
+        A Blueballs listing does not imply a partnership or production integration. Relationship and technical status remain explicit in the directory.
+
+        This is a public GitHub issue. Do not include credentials, customer information, confidential commercial terms or other sensitive data.
+  - type: input
+    id: provider
+    attributes:
+      label: Provider or infrastructure project
+      placeholder: Company or project name
+    validations:
+      required: true
+  - type: dropdown
+    id: request
+    attributes:
+      label: What are you proposing?
+      options:
+        - Add or update a directory listing
+        - Build a Blueballs adapter
+        - Document compatibility
+        - Explore an integration
+        - Correct provider information
+    validations:
+      required: true
+  - type: textarea
+    id: capabilities
+    attributes:
+      label: Capabilities
+      description: Accounts, rails, cards, KYC/KYB, custody, stablecoins, FX, treasury, reconciliation or other infrastructure.
+    validations:
+      required: true
+  - type: input
+    id: regions
+    attributes:
+      label: Regions or markets
+      placeholder: Global, US, UK, Europe, APAC...
+  - type: input
+    id: official
+    attributes:
+      label: Official product or documentation link
+      placeholder: https://...
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: What should Blueballs evaluate?
+      placeholder: Describe the listing, compatibility or adapter opportunity.
+  - type: checkboxes
+    id: public
+    attributes:
+      label: Public issue acknowledgement
+      options:
+        - label: I have not included secrets, customer data or confidential information.
+          required: true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
   <a href="https://blueballs.tech/cards">Cards</a> ·
   <a href="https://blueballs.tech/ecosystem">Providers</a> ·
   <a href="https://blueballs.tech/sandbox">Build in the Sandbox</a> ·
-  <a href="https://blueballs.tech/developers">API</a>
+  <a href="https://blueballs.tech/developers">API</a> ·
+  <a href="https://blueballs.tech/contact">Build with Blueballs</a>
 </p>
 
 <p align="center">
@@ -258,7 +259,9 @@ Use the core as-is for exploration. Fork it for your product. Build a provider a
 
 The project is deliberately provider-neutral and jurisdiction-flexible so serious teams can perform the additional integration, security, operational and regulatory work their own deployment requires without fighting a black-box platform.
 
-**[Explore Blueballs](https://blueballs.tech)** · **[Build in the Sandbox](https://blueballs.tech/sandbox)** · **[Read the API](https://blueballs.tech/developers)**
+**Blueballs is free to use. If you want the project involved in product design, integration, deployment or operating architecture, [build with Blueballs](https://blueballs.tech/contact).**
+
+**[Explore Blueballs](https://blueballs.tech)** · **[Build in the Sandbox](https://blueballs.tech/sandbox)** · **[Read the API](https://blueballs.tech/developers)** · **[Build with Blueballs](https://blueballs.tech/contact)**
 
 ## Documentation
 

--- a/index.html
+++ b/index.html
@@ -4,9 +4,39 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#07144F" />
+    <meta
+      name="description"
+      content="Open financial infrastructure for banking, institution-owned FX, provider orchestration and programmable financial products."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Blueballs" />
+    <meta property="og:title" content="Blueballs — open financial operating system" />
+    <meta
+      property="og:description"
+      content="Build the financial institution your market needs."
+    />
+    <meta property="og:url" content="https://blueballs.tech" />
+    <meta
+      property="og:image"
+      content="https://blueballs.tech/city/front-cover/blueballs-front-cover-v1.png"
+    />
+    <meta
+      property="og:image:alt"
+      content="Blueballs — build the financial institution your market needs"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Blueballs — open financial operating system" />
+    <meta
+      name="twitter:description"
+      content="Build the financial institution your market needs."
+    />
+    <meta
+      name="twitter:image"
+      content="https://blueballs.tech/city/front-cover/blueballs-front-cover-v1.png"
+    />
     <link rel="icon" href="/blueballs-mark.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/blueballs-mark.svg" />
-    <title>Blueballs — open-source neobank reference stack</title>
+    <title>Blueballs — open financial operating system</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/scripts/check-page-truth.mjs
+++ b/scripts/check-page-truth.mjs
@@ -24,10 +24,19 @@ const fxC = readFileSync(
   new URL("../src/fx/FinalFxSectionsC.tsx", import.meta.url),
   "utf8",
 );
+const contact = readFileSync(
+  new URL("../src/ContactPage.tsx", import.meta.url),
+  "utf8",
+);
+const crawler = readFileSync(
+  new URL("../workers/site/crawler-pages.js", import.meta.url),
+  "utf8",
+);
 const worker = readFileSync(
   new URL("../workers/site/index.js", import.meta.url),
   "utf8",
 );
+const index = readFileSync(new URL("../index.html", import.meta.url), "utf8");
 
 assert.match(
   publicSource,
@@ -37,13 +46,18 @@ assert.match(
 
 assert.match(
   readme,
-  /open-source operating system for modern financial institutions/i,
-  "README must lead with the Blueballs institution-platform position",
+  /Own the financial stack/i,
+  "README must lead with institution ownership rather than starter-template positioning",
+);
+assert.match(
+  readme,
+  /Build and operate your own FX market/i,
+  "README must surface the institution-owned FX position",
 );
 assert.match(
   readme,
   /adapter-driven production FX runtime/i,
-  "README must surface the production FX composition",
+  "README must surface production FX composition",
 );
 assert.match(
   fxA,
@@ -70,6 +84,31 @@ for (const stale of [
 }
 
 assert.match(
+  contact,
+  /Take Blueballs from open source to your market\./,
+  "the public contact route must convert design-partner and implementation interest",
+);
+assert.match(contact, /DESIGN PARTNER/);
+assert.match(contact, /IMPLEMENTATION/);
+assert.match(contact, /PROVIDERS/);
+assert.match(
+  crawler,
+  /Build and operate your own FX market\./,
+  "crawler content must carry the flagship FX position",
+);
+assert.match(crawler, /Take Blueballs from open source to your market\./);
+
+for (const metadata of [
+  /property="og:title"/,
+  /property="og:image"/,
+  /name="twitter:card" content="summary_large_image"/,
+]) {
+  assert.match(index, metadata, `share metadata missing: ${metadata}`);
+}
+assert.match(worker, /property="og:title"/);
+assert.match(worker, /name="twitter:title"/);
+
+assert.match(
   worker,
   /url\.pathname === "\/bulletin"[\s\S]*Response\.redirect\(new URL\("\/developers"[\s\S]*301/,
 );
@@ -79,5 +118,5 @@ assert.doesNotMatch(
 );
 
 console.log(
-  "page truth: source is linked, Blueballs positioning is capability-led, FX architecture copy is current, /bulletin is a 301",
+  "page truth: source is linked, ownership/FX positioning is current, build-with-us conversion exists, share metadata is present, /bulletin is a 301",
 );

--- a/scripts/check-site-routes.mjs
+++ b/scripts/check-site-routes.mjs
@@ -84,6 +84,11 @@ assert.match(
 );
 assert.match(
   siteRoot,
+  /if \(path === "\/contact"\)[\s\S]{0,120}<ContactPage onNavigate=\{navigate\} \/>/,
+  "SiteRoot must own the commercial /contact page",
+);
+assert.match(
+  siteRoot,
   /\["Stablecoin FX", "\/fx"\][\s\S]{0,180}\["Developers", "\/developers"\][\s\S]{0,180}\["Cards", "\/cards"\][\s\S]{0,180}\["Providers", "\/ecosystem"\]/,
   "directory pages must keep the same primary menu sequence as the main site",
 );
@@ -118,17 +123,18 @@ for (const stalePath of [
 
 assert.equal(
   pageMetadata("/cards").title,
-  "Card programme research — Blueballs",
+  "The stablecoin card market, mapped — Blueballs",
 );
-assert.match(crawlerDocument("/cards"), /not the Blueballs Cards API/i);
-assert.match(crawlerDocument("/cards"), /Not connected/);
+assert.match(crawlerDocument("/cards"), /independent|research standard/i);
+assert.match(crawlerDocument("/cards"), /relationship and technical status/i);
 assert.match(sitemapXml(), /<loc>https:\/\/blueballs\.tech\/cards<\/loc>/);
 assert.equal(
   pageMetadata("/sandbox").title,
   "Build a fintech sandbox — Blueballs",
 );
-assert.match(crawlerDocument("/sandbox"), /protected double-entry ledger/i);
+assert.match(crawlerDocument("/sandbox"), /protected-ledger payment journeys/i);
 assert.match(sitemapXml(), /<loc>https:\/\/blueballs\.tech\/sandbox<\/loc>/);
+assert.match(sitemapXml(), /<loc>https:\/\/blueballs\.tech\/contact<\/loc>/);
 assert.equal(
   canonicalRedirectUrl("http://blueballs.tech/sandbox", "blueballs.tech", true),
   null,
@@ -154,5 +160,5 @@ assert.match(preview, /wrangler\.api\.jsonc/);
 assert.match(preview, /wrangler\.fx\.jsonc/);
 assert.match(preview, /LOCAL_DEV:true/);
 console.log(
-  "site route contract: shared navigation is synchronized and Cards has one canonical public implementation",
+  "site route contract: shared navigation is synchronized, Cards has one canonical market-intelligence surface, and /contact is a first-class build route",
 );

--- a/src/ContactPage.tsx
+++ b/src/ContactPage.tsx
@@ -1,0 +1,390 @@
+import { BrandLockup } from "./Brand";
+
+const MONO = "'IBM Plex Mono', monospace";
+const REPO = "https://github.com/Josh-Gi3r/blueballs";
+const ISSUE = `${REPO}/issues/new?template=`;
+
+type ContactPageProps = { onNavigate: (path: string) => void };
+
+const paths = [
+  {
+    eyebrow: "DESIGN PARTNER",
+    title: "Design a financial product with Blueballs.",
+    body: "For founders, institutions and product teams defining a new bank, stablecoin product, money-movement experience or institution-owned FX market.",
+    action: "Start a design-partner brief",
+    href: `${ISSUE}design_partner.yml`,
+  },
+  {
+    eyebrow: "IMPLEMENTATION",
+    title: "Turn the open-source stack into your stack.",
+    body: "For teams that want help with architecture, provider adapters, ledger integration, deployment, operating design or production hardening.",
+    action: "Discuss an implementation",
+    href: `${ISSUE}implementation.yml`,
+  },
+  {
+    eyebrow: "PROVIDERS",
+    title: "Connect infrastructure to Blueballs.",
+    body: "For banks, issuers, card platforms, KYC providers, custodians, payment rails, stablecoin infrastructure, liquidity venues and other financial providers.",
+    action: "Open a provider brief",
+    href: `${ISSUE}provider.yml`,
+  },
+  {
+    eyebrow: "OPEN SOURCE",
+    title: "Fork it. Extend it. Ship something new.",
+    body: "Blueballs is MIT licensed. You do not need permission to use the code. Contributions, product ideas, adapters and new financial primitives are welcome.",
+    action: "Build on GitHub",
+    href: REPO,
+  },
+] as const;
+
+export default function ContactPage({ onNavigate }: ContactPageProps) {
+  const nav = [
+    ["Home", "/home"],
+    ["Products", "/products"],
+    ["Stablecoin FX", "/fx"],
+    ["Cards", "/cards"],
+    ["Providers", "/ecosystem"],
+    ["Developers", "/developers"],
+  ] as const;
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "#E8EAEF",
+        color: "#07144F",
+        fontFamily: "Archivo, system-ui, sans-serif",
+        padding: 16,
+      }}
+    >
+      <div
+        style={{
+          width: "100%",
+          maxWidth: 1200,
+          margin: "0 auto",
+          display: "flex",
+          flexDirection: "column",
+          gap: 14,
+        }}
+      >
+        <header
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 16,
+            flexWrap: "wrap",
+            padding: "12px 20px",
+            background: "#fff",
+            border: "1px solid #D7DBE4",
+            borderRadius: 14,
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => onNavigate("/home")}
+            style={{
+              border: 0,
+              background: "transparent",
+              padding: 0,
+              cursor: "pointer",
+              color: "#07144F",
+              marginRight: "auto",
+            }}
+          >
+            <BrandLockup linked={false} />
+          </button>
+          <nav style={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            {nav.map(([label, path]) => (
+              <button
+                key={path}
+                type="button"
+                onClick={() => onNavigate(path)}
+                style={{
+                  border: 0,
+                  background: "transparent",
+                  color: "#5B6376",
+                  padding: "9px 11px",
+                  borderRadius: 8,
+                  cursor: "pointer",
+                  fontSize: 13,
+                }}
+              >
+                {label}
+              </button>
+            ))}
+          </nav>
+          <button
+            type="button"
+            onClick={() => onNavigate("/sandbox")}
+            style={{
+              border: "1px solid #07144F",
+              borderRadius: 10,
+              background: "#07144F",
+              color: "#fff",
+              padding: "10px 16px",
+              cursor: "pointer",
+              fontWeight: 600,
+            }}
+          >
+            Try the sandbox
+          </button>
+        </header>
+
+        <main style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <section
+            style={{
+              background: "#07144F",
+              color: "#fff",
+              borderRadius: 22,
+              padding: "clamp(34px, 6vw, 76px)",
+              overflow: "hidden",
+            }}
+          >
+            <div
+              style={{
+                fontFamily: MONO,
+                fontSize: 11,
+                letterSpacing: ".18em",
+                color: "#92A9FF",
+                marginBottom: 18,
+              }}
+            >
+              BUILD WITH BLUEBALLS
+            </div>
+            <h1
+              style={{
+                margin: 0,
+                maxWidth: "12ch",
+                fontSize: "clamp(42px, 7vw, 84px)",
+                lineHeight: .98,
+                letterSpacing: "-.055em",
+                fontWeight: 600,
+              }}
+            >
+              Take Blueballs from open source to your market.
+            </h1>
+            <p
+              style={{
+                maxWidth: "64ch",
+                margin: "26px 0 0",
+                fontSize: "clamp(17px, 2vw, 21px)",
+                lineHeight: 1.6,
+                color: "#C9D0E4",
+              }}
+            >
+              Blueballs is free to use. If you want the project involved in
+              designing, integrating, deploying or operating it, start here.
+              Bring the market, the product and the regulated relationships you
+              need. Blueballs brings the financial core and the architecture to
+              build on.
+            </p>
+            <div
+              style={{
+                display: "flex",
+                gap: 10,
+                flexWrap: "wrap",
+                marginTop: 30,
+              }}
+            >
+              <a
+                href={`${ISSUE}design_partner.yml`}
+                style={{
+                  textDecoration: "none",
+                  background: "#fff",
+                  color: "#07144F",
+                  borderRadius: 10,
+                  padding: "12px 18px",
+                  fontWeight: 600,
+                }}
+              >
+                Become a design partner →
+              </a>
+              <button
+                type="button"
+                onClick={() => onNavigate("/developers")}
+                style={{
+                  background: "transparent",
+                  color: "#fff",
+                  border: "1px solid #66729B",
+                  borderRadius: 10,
+                  padding: "12px 18px",
+                  fontWeight: 600,
+                  cursor: "pointer",
+                }}
+              >
+                Inspect the API
+              </button>
+            </div>
+          </section>
+
+          <section
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+              gap: 14,
+            }}
+          >
+            {paths.map((item) => (
+              <article
+                key={item.eyebrow}
+                style={{
+                  minHeight: 280,
+                  background: "#fff",
+                  border: "1px solid #D7DBE4",
+                  borderRadius: 18,
+                  padding: 26,
+                  display: "flex",
+                  flexDirection: "column",
+                }}
+              >
+                <div
+                  style={{
+                    fontFamily: MONO,
+                    fontSize: 10,
+                    letterSpacing: ".16em",
+                    color: "#0647E8",
+                  }}
+                >
+                  {item.eyebrow}
+                </div>
+                <h2
+                  style={{
+                    margin: "15px 0 12px",
+                    fontSize: 24,
+                    lineHeight: 1.12,
+                    letterSpacing: "-.035em",
+                  }}
+                >
+                  {item.title}
+                </h2>
+                <p
+                  style={{
+                    margin: 0,
+                    color: "#5B6376",
+                    fontSize: 14.5,
+                    lineHeight: 1.6,
+                  }}
+                >
+                  {item.body}
+                </p>
+                <a
+                  href={item.href}
+                  style={{
+                    marginTop: "auto",
+                    paddingTop: 24,
+                    color: "#0647E8",
+                    textDecoration: "none",
+                    fontFamily: MONO,
+                    fontSize: 11,
+                    fontWeight: 600,
+                  }}
+                >
+                  {item.action} →
+                </a>
+              </article>
+            ))}
+          </section>
+
+          <section
+            style={{
+              background: "#fff",
+              border: "1px solid #D7DBE4",
+              borderRadius: 18,
+              padding: "30px clamp(24px, 5vw, 52px)",
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
+              gap: 28,
+            }}
+          >
+            <div>
+              <div
+                style={{
+                  fontFamily: MONO,
+                  fontSize: 10,
+                  letterSpacing: ".16em",
+                  color: "#7A8296",
+                }}
+              >
+                OPEN SOURCE FIRST
+              </div>
+              <h2 style={{ margin: "12px 0 8px", fontSize: 28 }}>
+                You never need permission to fork Blueballs.
+              </h2>
+              <p style={{ margin: 0, color: "#5B6376", lineHeight: 1.65 }}>
+                The commercial path is for teams that want Blueballs involved
+                in product design, integration, deployment, provider composition
+                or operating architecture. The MIT-licensed core stays open.
+              </p>
+            </div>
+            <div>
+              <div
+                style={{
+                  fontFamily: MONO,
+                  fontSize: 10,
+                  letterSpacing: ".16em",
+                  color: "#7A8296",
+                }}
+              >
+                PUBLIC INTAKE
+              </div>
+              <h2 style={{ margin: "12px 0 8px", fontSize: 28 }}>
+                Start in public. Move sensitive work off the issue.
+              </h2>
+              <p style={{ margin: 0, color: "#5B6376", lineHeight: 1.65 }}>
+                The GitHub forms are for a non-confidential first brief. Never
+                post credentials, customer data, security details or private
+                commercial terms in a public issue.
+              </p>
+            </div>
+          </section>
+        </main>
+
+        <footer
+          style={{
+            background: "#07144F",
+            color: "#fff",
+            borderRadius: 18,
+            padding: 26,
+            display: "flex",
+            justifyContent: "space-between",
+            gap: 20,
+            flexWrap: "wrap",
+          }}
+        >
+          <div>
+            <BrandLockup compact inverse />
+            <div
+              style={{
+                marginTop: 10,
+                maxWidth: "46ch",
+                color: "#C5CAD7",
+                fontSize: 13.5,
+                lineHeight: 1.6,
+              }}
+            >
+              MIT-licensed open financial infrastructure for teams that want to
+              own the product, the money logic and the provider composition.
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 18, alignItems: "center" }}>
+            <button
+              type="button"
+              onClick={() => onNavigate("/sandbox")}
+              style={{
+                border: 0,
+                background: "transparent",
+                color: "#fff",
+                cursor: "pointer",
+              }}
+            >
+              Sandbox
+            </button>
+            <a href={REPO} style={{ color: "#fff", textDecoration: "none" }}>
+              GitHub
+            </a>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/EcosystemPage.tsx
+++ b/src/EcosystemPage.tsx
@@ -6,7 +6,7 @@ import "./EcosystemPage.css";
 const MONO = "'IBM Plex Mono', monospace";
 type EcosystemPageProps = { onNavigate: (path: string) => void };
 const FILLER_COPY = [
-  ["DIRECTORY", "Provider candidates."],
+  ["DIRECTORY", "Provider landscape."],
   ["OPEN SOURCE", "Free to fork and self-host."],
   ["SOURCES", "Links to official websites."],
 ] as const;
@@ -187,7 +187,7 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
             {filtered.length} {filtered.length === 1 ? "listing" : "listings"}
           </span>
           <span>
-            Reviewed against official provider information · 12 Aug 2026
+            Reviewed against official provider information · 20 Aug 2026
           </span>
         </div>
         <div className="eco-provider-grid">
@@ -222,18 +222,19 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
           <button
             type="button"
             className="secondary"
-            onClick={() => onNavigate("/fx")}
+            onClick={() => onNavigate("/contact")}
           >
-            See Stablecoin FX
+            Build an adapter
           </button>
         </div>
       </section>
       <div className="eco-disclaimer">
         <span style={{ fontFamily: MONO }}>ABOUT THIS DIRECTORY</span>
         <p>
-          Access and sandbox details were checked against official provider
-          information on 12 Aug 2026. Products and availability change, so check
-          the provider's current documentation before building.
+          Listings link to official provider sources and show relationship and
+          technical status explicitly. Access and sandbox details were reviewed
+          on 20 Aug 2026. Products and availability change, so check the
+          provider's current documentation before building.
         </p>
       </div>
     </div>

--- a/src/SiteRoot.tsx
+++ b/src/SiteRoot.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useEffect, useState } from "react";
 import App from "./App";
 import EcosystemPage from "./EcosystemPage";
 import CardsPage from "./CardsPage";
+import ContactPage from "./ContactPage";
 import { BrandLockup } from "./Brand";
 import { usePath } from "./router";
 import SandboxPage from "./sandbox/SandboxPage";
@@ -31,6 +32,7 @@ function DirectoryShell({
     ["Developers", "/developers"],
     ["Cards", "/cards"],
     ["Providers", "/ecosystem"],
+    ["Build with us", "/contact"],
   ] as const;
   const active = page === "cards" ? "/cards" : "/ecosystem";
   const ticker =
@@ -278,8 +280,8 @@ function DirectoryShell({
                 maxWidth: "36ch",
               }}
             >
-              MIT-licensed open-source software for building neobanks and
-              financial products.
+              MIT-licensed open financial operating system for banking, FX and
+              programmable financial products.
             </p>
             <div style={{ fontFamily: MONO, fontSize: 10.5, color: "#8F98AC" }}>
               © 2026 · MIT LICENCE
@@ -317,6 +319,12 @@ function DirectoryShell({
               className="eco-shell-link"
             >
               Providers
+            </button>
+            <button
+              onClick={() => navigate("/contact")}
+              className="eco-shell-link"
+            >
+              Build with us
             </button>
           </div>
           <div>
@@ -375,5 +383,6 @@ export default function SiteRoot() {
   if (path === "/cards")
     return <DirectoryShell page="cards" navigate={navigate} />;
   if (path === "/sandbox") return <SandboxPage />;
+  if (path === "/contact") return <ContactPage onNavigate={navigate} />;
   return <App />;
 }

--- a/workers/site/crawler-pages.js
+++ b/workers/site/crawler-pages.js
@@ -8,6 +8,7 @@ const NAV = [
   ["Providers", "/ecosystem"],
   ["Sandbox", "/sandbox"],
   ["Developers", "/developers"],
+  ["Build with Blueballs", "/contact"],
 ];
 const PRODUCTS = [
   "Accounts",
@@ -75,61 +76,63 @@ const PAGES = {
   "/": {
     title: "Blueballs — build the financial institution your market needs",
     description:
-      "Open-source financial infrastructure. Enter from the landing cover into accounts, cards, transfers, wallets, ledger and FX.",
-    body: `<h1>Build the financial institution your market needs.</h1><p>Accounts, cards, transfers, wallets and FX in one open-source stack. Connect the providers your product needs.</p><p><a href="/home">Open the homepage</a> or <a href="/sandbox">try the sandbox</a>.</p>`,
+      "Open financial infrastructure for banking, institution-owned FX, provider orchestration and programmable financial products.",
+    body: `<h1>Build the financial institution your market needs.</h1><p>Banking, cards, payments, wallets, ledger, provider orchestration and institution-owned FX in one MIT-licensed stack.</p><p><a href="/home">Explore Blueballs</a>, <a href="/sandbox">build in the sandbox</a> or <a href="https://github.com/Josh-Gi3r/blueballs">inspect the source</a>.</p>`,
   },
   "/home": {
-    title: "Blueballs — open-source software for building a neobank",
+    title: "Blueballs — open financial operating system",
     description:
-      "Open-source software for building accounts, cards, transfers, onboarding, wallets, ledger and FX into your own financial product.",
-    body: `<h1>Open-source software for building a neobank.</h1><p>Blueballs gives you software for accounts, cards, transfers, onboarding, wallets, ledger, FX and other financial products. It is MIT licensed, self-hostable and built to be changed.</p><h2>Build the bank for your People.</h2><p>A company. A community. A city. An industry. A marketplace. Or something nobody has built yet.</p><h2>What is included</h2>${list(PRODUCTS)}<p><a href="/sandbox">Start with the hosted sandbox</a> or <a href="https://github.com/Josh-Gi3r/blueballs">view the source on GitHub</a>.</p>`,
+      "An MIT-licensed financial operating system for banking products, provider orchestration, stablecoin FX and programmable money movement.",
+    body: `<h1>Own the financial stack.</h1><p>Blueballs puts the product, ledger, provider composition and FX control plane in the hands of the institution building the experience. Clone it, inspect it, fork it and connect the infrastructure your market needs.</p><h2>Build the financial institution your market needs.</h2><p>A company. A community. A city. An industry. A marketplace. Or something nobody has built yet.</p><h2>What ships in Blueballs</h2>${list(PRODUCTS)}<p><a href="/sandbox">Build in the sandbox</a>, <a href="/developers">inspect the API</a> or <a href="/contact">build with Blueballs</a>.</p>`,
   },
   "/products": {
-    title: "Products — Blueballs",
+    title: "Financial products — Blueballs",
     description:
-      "Accounts, cards, transfers, onboarding, wallets, ledger, FX and other financial-product software included in Blueballs.",
-    body: `<h1>Build the financial products your bank needs.</h1><p>Start with accounts, cards, transfers, onboarding, wallets, FX, business banking and more. Use the pieces you need, change them for your product and connect the providers your production deployment requires.</p><h2>See it in a product</h2><p>Walk through onboarding, funding, spending and payouts to see how Blueballs can sit behind a financial product. Each step pairs the customer experience with the API call behind it.</p>${list(PRODUCTS)}<p><a href="/developers">See the API</a></p>`,
+      "Accounts, cards, transfers, onboarding, wallets, ledger, FX and financial-product primitives built on one open financial core.",
+    body: `<h1>Build the financial products your market needs.</h1><p>Start with accounts, cards, transfers, onboarding, wallets, FX, business banking and more. Keep one financial core while the customer experience, providers and market composition evolve around it.</p><h2>See the product and the contract together</h2><p>Walk through onboarding, funding, spending and payouts with the API call behind each experience.</p>${list(PRODUCTS)}<p><a href="/developers">Inspect the API</a> or <a href="/contact">build an implementation</a>.</p>`,
   },
   "/fx": {
-    title: "Stablecoin FX — Blueballs",
+    title: "Build and operate your own FX market — Blueballs",
     description:
-      "Open-source FX software for customer quotes, pricing policy, liquidity routing, treasury limits and settlement tracking.",
-    body: `<h1>Build FX into your financial product.</h1><p>Quote customers in familiar currencies while stablecoins, liquidity providers and treasury inventory can sit underneath. Blueballs covers pricing policy, source selection, reservations and settlement records.</p><p>BRL to EUR is the interactive browser simulation, not the scope of the product and not a call to the FX node.</p><h2>Included components</h2>${list(["FX node and JavaScript SDK", "Participant and corridor policy", "Market and principal pricing", "Liquidity routing", "Fiat settlement intents", "Settlement contracts", "Failure simulator"])}<p>The FX node ships with the stack. The browser demo runs on deterministic data, so every number it shows is one you can reproduce from source: <a href=\"https://github.com/Josh-Gi3r/blueballs\">github.com/Josh-Gi3r/blueballs</a>.</p>`,
+      "Open-source FX control plane for policy, pricing, liquidity, treasury, routing, reservations, execution and settlement.",
+    body: `<h1>Build and operate your own FX market.</h1><p>Blueballs treats stablecoin FX as an institution-owned market and control plane. Combine private orders, issuer inventory, professional makers, treasury or principal capacity and external venues behind one policy and lifecycle model.</p><h2>Included components</h2>${list(["Canonical FX node and JavaScript SDK", "Participant and corridor policy", "Exact market and principal pricing", "Multi-source liquidity routing", "Capacity reservation", "Fiat settlement evidence", "Atomic token settlement contracts", "Failure and reconciliation simulation"])}<p>The interactive architecture lab uses deterministic reference data so its behaviour is reproducible from source. Production deployments connect market, liquidity, fiat and execution infrastructure through the FX runtime adapter.</p><p><a href="/contact">Build an FX implementation</a> or <a href="https://github.com/Josh-Gi3r/blueballs">inspect the source</a>.</p>`,
   },
   "/cards": {
-    title: "Card programme research — Blueballs",
+    title: "The stablecoin card market, mapped — Blueballs",
     description:
-      "A sourced research directory of stablecoin and crypto card programmes; not the Blueballs Cards API and not connected integrations.",
-    body: `<h1>Card programme research.</h1><p>Compare public card-programme models, funding patterns, custody boundaries, networks and disclosed infrastructure. This page is research for product design; it is not the Blueballs Cards API, a recommendation, or evidence of a working integration.</p><h2>Status</h2><p>Every programme must carry a source URL, source date, jurisdiction and confidence label. Named companies remain Not connected unless separately evidenced.</p><p><a href="/developers">Inspect the sandbox Cards API</a></p>`,
+      "Independent, sourced market intelligence for stablecoin and crypto card programmes, funding models, custody, networks and infrastructure.",
+    body: `<h1>The stablecoin card market, mapped.</h1><p>Compare public card-programme models, funding patterns, custody boundaries, networks and disclosed infrastructure, then use the research to design your own card product on Blueballs.</p><h2>Research standard</h2><p>Each programme carries source, jurisdiction and confidence information. Relationship and technical status are shown explicitly so market research stays separate from claimed Blueballs integrations.</p><p><a href="/developers">Inspect the Blueballs Cards API</a> or <a href="/contact">build a card programme</a>.</p>`,
   },
   "/ecosystem": {
-    title: "Provider directory — Blueballs",
+    title: "Financial infrastructure provider directory — Blueballs",
     description:
-      "A directory of banking and financial-infrastructure providers, grouped by service and region.",
-    body: `<h1>Find the services your product needs.</h1><p>Compare companies that provide banking, identity, payments, cards, custody, liquidity and other financial infrastructure. Blueballs is the software layer; you choose the providers behind your product.</p>${list(PROVIDER_CATEGORIES)}<p>The directory is a research tool, not a ranking or recommendation. Listings do not imply a partnership or existing integration.</p>`,
+      "Compare banking, identity, payments, cards, custody, stablecoin, FX and operations infrastructure by capability and region.",
+    body: `<h1>Choose the infrastructure behind your product.</h1><p>Blueballs keeps the software core provider-neutral. Use the directory to compare banking, identity, payments, cards, custody, liquidity and other infrastructure while keeping provider relationships outside the canonical financial model.</p>${list(PROVIDER_CATEGORIES)}<p>Listings link to official sources. Relationship and technical status are shown explicitly; a listing does not by itself claim a Blueballs partnership or production integration.</p><p><a href="/contact">Build an adapter or add a provider</a>.</p>`,
   },
   "/sandbox": {
     title: "Build a fintech sandbox — Blueballs",
     description:
-      "Turn a financial-product brief into a structured blueprint, provision test users and balances, and run protected-ledger test payments.",
-    body: `<h1>Build a working fintech sandbox.</h1><p>Describe the people you serve, choose markets, currencies, capabilities and rails, then review a structured blueprint. Blueballs provisions isolated test customers, accounts and balances and lets you run a payment through the protected double-entry ledger.</p><h2>What the builder creates</h2>${list(["Structured product blueprint", "Tenant-isolated test environment", "Approved test customers", "Multi-currency sandbox accounts", "Seeded test balances", "Protected-ledger payment journeys"])}`,
+      "Turn a financial-product brief into a structured blueprint, isolated test environment and protected-ledger product journey.",
+    body: `<h1>Design the product. Provision the sandbox. Run the money flow.</h1><p>Describe the people you serve, choose markets, currencies, capabilities and rails, then turn the brief into an isolated Blueballs environment with test customers, accounts, balances and ledger-backed payment journeys.</p><h2>What the Builder creates</h2>${list(["Structured product blueprint", "Tenant-isolated test environment", "Approved test customers", "Multi-currency sandbox accounts", "Seeded test balances", "Protected-ledger payment journeys"])}<p><a href="/contact">Take the design into implementation</a>.</p>`,
   },
   "/developers": {
-    title: "Developers — Blueballs",
-    description: "Create a sandbox key and inspect the Blueballs API contract.",
-    body: `<h1>Build with Blueballs.</h1><p>Create a sandbox key without applying for access and inspect the contract now. Or run the whole stack yourself: <code>git clone https://github.com/Josh-Gi3r/blueballs.git &amp;&amp; pnpm install &amp;&amp; pnpm dev</code>.</p><p>The hosted sandbox creates development state. It does not move real money or call production providers.</p><h2>API families</h2>${list(API_FAMILIES)}<p><a href="/openapi.yaml">OpenAPI specification</a></p>`,
+    title: "Build with the Blueballs API",
+    description:
+      "Create a sandbox key, inspect the financial contracts and run the complete open-source banking and FX stack yourself.",
+    body: `<h1>Inspect it. Run it. Build on it.</h1><p>Create a sandbox key without applying for access and inspect the contract now. Or run the complete stack yourself: <code>git clone https://github.com/Josh-Gi3r/blueballs.git &amp;&amp; pnpm install &amp;&amp; pnpm dev</code>.</p><p>The hosted environment uses isolated test state. Production deployments connect their own provider adapters, credentials and operating policy around the same core contracts.</p><h2>API families</h2>${list(API_FAMILIES)}<p><a href="/openapi.yaml">OpenAPI specification</a> · <a href="/contact">Build an implementation</a></p>`,
   },
   "/contact": {
-    title: "Contact — Blueballs",
-    description: "Source, issues and security contact for Blueballs.",
-    body: `<h1>Contact Blueballs</h1><p>The source, the issue tracker and private vulnerability reporting are all open at <a href=\"https://github.com/Josh-Gi3r/blueballs\">github.com/Josh-Gi3r/blueballs</a>. The hosted sandbox and the API contract are on the developer page.</p>`,
+    title: "Build with Blueballs",
+    description:
+      "Design partner, implementation and provider routes for teams taking Blueballs from open source into a financial product or institution.",
+    body: `<h1>Take Blueballs from open source to your market.</h1><p>Blueballs is free to use. Teams that want the project involved in product design, architecture, provider adapters, deployment or operating design can start a public non-confidential brief.</p><h2>Ways to build together</h2>${list(["Design a financial product with Blueballs", "Implement and adapt the open-source stack", "Connect a financial-infrastructure provider", "Contribute code, adapters, research or new primitives"])}<p><a href="https://github.com/Josh-Gi3r/blueballs/issues/new?template=design_partner.yml">Start a design-partner brief</a> or <a href="https://github.com/Josh-Gi3r/blueballs/issues/new?template=implementation.yml">discuss an implementation</a>.</p>`,
   },
 };
 export const PUBLIC_PATHS = Object.keys(PAGES);
 export function crawlerDocument(pathname) {
   const page = PAGES[pathname] ?? PAGES["/"];
   const canonical = `${SITE}${pathname === "/" ? "" : pathname}`;
-  return `<div id="root" data-server-content="true"><header><a href="/">Blueballs</a><nav>${NAV.map(([label, path]) => `<a href="${path}">${label}</a>`).join(" ")}</nav></header><main>${page.body}</main><footer><p>Blueballs is MIT-licensed open-source software.</p></footer></div><script type="application/ld+json">${JSON.stringify({ "@context": "https://schema.org", "@type": pathname === "/" ? "SoftwareApplication" : "WebPage", name: page.title, description: page.description, url: canonical, isPartOf: { "@type": "WebSite", name: "Blueballs", url: SITE } })}</script>`;
+  return `<div id="root" data-server-content="true"><header><a href="/">Blueballs</a><nav>${NAV.map(([label, path]) => `<a href="${path}">${label}</a>`).join(" ")}</nav></header><main>${page.body}</main><footer><p>Blueballs is an MIT-licensed open financial operating system.</p></footer></div><script type="application/ld+json">${JSON.stringify({ "@context": "https://schema.org", "@type": pathname === "/" ? "SoftwareApplication" : "WebPage", name: page.title, description: page.description, url: canonical, isPartOf: { "@type": "WebSite", name: "Blueballs", url: SITE } })}</script>`;
 }
 export function pageMetadata(pathname) {
   return PAGES[pathname] ?? PAGES["/"];
@@ -144,7 +147,7 @@ export function sitemapXml() {
   return `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${entries}</urlset>`;
 }
 export function llmsText(full = false) {
-  const intro = `# Blueballs\n\nBlueballs is free, MIT-licensed, self-hostable software for building neobanks and financial products. It includes software and sandbox APIs for accounts, cards, transfers, onboarding, ledger, wallets and FX. Production deployments connect the regulated providers they need.\n\n## Public pages\n${NAV.map(([label, path]) => `- [${label}](${SITE}${path})`).join("\n")}\n\n## Contract and source status\n- [OpenAPI specification](${SITE}/openapi.yaml)\n- [Source](https://github.com/Josh-Gi3r/blueballs) — MIT, clone and run it.\n`;
+  const intro = `# Blueballs\n\nBlueballs is a free, MIT-licensed, self-hostable financial operating system for banking products, provider orchestration, institution-owned stablecoin FX and programmable financial infrastructure. The repository combines product interfaces, banking and ledger contracts, provider boundaries, FX policy/pricing/routing, settlement primitives and release proof. Production deployments connect the regulated providers, credentials and jurisdiction-specific operating policy they require.\n\n## Public pages\n${NAV.map(([label, path]) => `- [${label}](${SITE}${path})`).join("\n")}\n\n## Contract and source status\n- [Banking OpenAPI specification](${SITE}/openapi.yaml)\n- [FX OpenAPI specification](${SITE}/openapi.fx.yaml)\n- [Source](https://github.com/Josh-Gi3r/blueballs) — MIT licensed. Clone, inspect, fork and run it.\n- [Build with Blueballs](${SITE}/contact) — design partner, implementation and provider routes.\n`;
   if (!full) return intro;
   return `${intro}\n## Page summaries\n${PUBLIC_PATHS.map((path) => {
     const page = PAGES[path];

--- a/workers/site/index.js
+++ b/workers/site/index.js
@@ -12,8 +12,16 @@ import { getAgentByName } from "agents";
 export { NeobankBuilder } from "./neobank-builder.js";
 export { BuilderBudget } from "./builder-budget.js";
 
+const SOCIAL_IMAGE =
+  "https://blueballs.tech/city/front-cover/blueballs-front-cover-v1.png";
 const sourceKey = (request) =>
   request.headers.get("cf-connecting-ip") || "unknown-source";
+const escapeAttribute = (value) =>
+  String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
 
 async function withinLimit(binding, key) {
   if (!binding?.limit) return true;
@@ -273,13 +281,53 @@ async function handleRequest(request, env) {
 
   const known = KNOWN_PAGES.has(url.pathname);
   const metadata = pageMetadata(url.pathname);
+  const canonical = `https://blueballs.tech${url.pathname === "/" ? "" : url.pathname}`;
+  const title = escapeAttribute(metadata.title);
+  const description = escapeAttribute(metadata.description);
+  const canonicalAttribute = escapeAttribute(canonical);
   let html = await assetResponse.text();
   html = html
-    .replace(/<title>.*?<\/title>/s, `<title>${metadata.title}</title>`)
+    .replace(/<title>.*?<\/title>/s, `<title>${title}</title>`)
+    .replace(
+      /<meta\s+name="description"[^>]*>/i,
+      `<meta name="description" content="${description}" />`,
+    )
+    .replace(
+      /<meta\s+property="og:title"[^>]*>/i,
+      `<meta property="og:title" content="${title}" />`,
+    )
+    .replace(
+      /<meta\s+property="og:description"[^>]*>/i,
+      `<meta property="og:description" content="${description}" />`,
+    )
+    .replace(
+      /<meta\s+property="og:url"[^>]*>/i,
+      `<meta property="og:url" content="${canonicalAttribute}" />`,
+    )
+    .replace(
+      /<meta\s+property="og:image"[^>]*>/i,
+      `<meta property="og:image" content="${SOCIAL_IMAGE}" />`,
+    )
+    .replace(
+      /<meta\s+property="og:image:alt"[^>]*>/i,
+      `<meta property="og:image:alt" content="${title}" />`,
+    )
+    .replace(
+      /<meta\s+name="twitter:title"[^>]*>/i,
+      `<meta name="twitter:title" content="${title}" />`,
+    )
+    .replace(
+      /<meta\s+name="twitter:description"[^>]*>/i,
+      `<meta name="twitter:description" content="${description}" />`,
+    )
+    .replace(
+      /<meta\s+name="twitter:image"[^>]*>/i,
+      `<meta name="twitter:image" content="${SOCIAL_IMAGE}" />`,
+    )
     .replace('<div id="root"></div>', crawlerDocument(url.pathname))
     .replace(
       "</head>",
-      `<meta name="description" content="${metadata.description}"><link rel="canonical" href="https://blueballs.tech${url.pathname === "/" ? "" : url.pathname}"><link rel="alternate" type="text/plain" href="/llms.txt" title="LLM overview"></head>`,
+      `<link rel="canonical" href="${canonicalAttribute}"><link rel="alternate" type="text/plain" href="/llms.txt" title="LLM overview"></head>`,
     );
 
   const headers = new Headers(assetResponse.headers);


### PR DESCRIPTION
## Blueballs build surface

This expands the public product around the open financial operating system so builders, institutions and infrastructure providers have clear ways to explore, evaluate and build with the project.

## Included

- first-class **Build with Blueballs** route for design partners, implementations and provider ecosystem work;
- structured public intake for design-partner, implementation and provider briefs;
- provider directory provenance aligned with the underlying source date;
- Cards, FX, provider and developer discovery copy aligned with the current product architecture;
- route-specific Open Graph and X/Twitter metadata for shareable public pages;
- README links from open-source exploration into design and implementation routes;
- publication-truth and route-contract checks updated to protect the new public surfaces.

## Product boundary

Blueballs remains MIT licensed and free to fork. Public intake is non-confidential. Provider listings and technical status remain explicit and do not imply partnerships or production integrations.

## Runtime impact

No banking, ledger, FX pricing, settlement or provider-finality semantics are changed. This change expands public product routing, discovery metadata, provider provenance and project intake.