### PR TITLE
Open the Blueballs builder showcase

### DIFF
--- a/.github/ISSUE_TEMPLATE/showcase.yml
+++ b/.github/ISSUE_TEMPLATE/showcase.yml
@@ -1,0 +1,54 @@
+name: Built with Blueballs
+description: Share a product, adapter, experiment or financial primitive you built with Blueballs.
+title: "[Showcase] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Show what you built
+        Blueballs is open infrastructure. If you forked it, extended it, built an adapter, designed a product or used the financial primitives in something worth seeing, share it here.
+
+        This is a public GitHub issue. Only include information you are comfortable publishing.
+  - type: input
+    id: project
+    attributes:
+      label: Project
+      placeholder: Product, company, experiment or repository name
+    validations:
+      required: true
+  - type: textarea
+    id: built
+    attributes:
+      label: What did you build?
+      placeholder: Tell the community what the product or infrastructure does and which parts of Blueballs you used.
+    validations:
+      required: true
+  - type: input
+    id: link
+    attributes:
+      label: Public link
+      placeholder: https://...
+  - type: checkboxes
+    id: surfaces
+    attributes:
+      label: Blueballs surfaces used
+      options:
+        - label: Banking API and ledger
+        - label: Cards or payments
+        - label: Provider adapters
+        - label: Stablecoin FX or treasury
+        - label: Settlement contracts
+        - label: Sandbox or product interfaces
+        - label: Other Blueballs primitives
+  - type: textarea
+    id: learnings
+    attributes:
+      label: What did you learn or change?
+      placeholder: Architecture choices, extensions, market adaptations, provider work or ideas others may find useful.
+  - type: checkboxes
+    id: public
+    attributes:
+      label: Public submission
+      options:
+        - label: I am comfortable sharing this information publicly in the Blueballs repository.
+          required: true

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -1,0 +1,33 @@
+# Built with Blueballs
+
+Blueballs is designed to be forked, adapted and taken into markets the core project could never cover alone.
+
+If you use Blueballs to build a product, provider adapter, treasury workflow, FX market, settlement primitive, internal financial platform or a useful experiment, show the community what you made.
+
+## Share what you built
+
+Open a **Built with Blueballs** showcase submission:
+
+https://github.com/Josh-Gi3r/blueballs/issues/new?template=showcase.yml
+
+Useful submissions can include:
+
+- a public financial product or prototype;
+- a provider or infrastructure adapter;
+- a market-specific implementation;
+- a new card, payments or treasury architecture;
+- an extension to the banking or FX core;
+- a new financial primitive or settlement pattern;
+- a technical write-up that teaches other builders something useful.
+
+The showcase is for real work. Blueballs will not invent customer logos, partnerships or adoption claims. Projects belong here when the people building them choose to share them publicly.
+
+## Build something first
+
+- **Explore the product:** https://blueballs.tech
+- **Build in the sandbox:** https://blueballs.tech/sandbox
+- **Inspect the APIs:** https://blueballs.tech/developers
+- **Fork the source:** https://github.com/Josh-Gi3r/blueballs/fork
+- **Build with Blueballs:** https://blueballs.tech/contact
+
+MIT licensed. Take the code somewhere interesting.


### PR DESCRIPTION
## Built with Blueballs

Give builders a public path to bring forks, adapters, experiments and market-specific implementations back into the project.

## Included

- root `SHOWCASE.md` explaining what belongs in the community showcase;
- **Built with Blueballs** issue form for products, provider adapters, FX/treasury work, settlement primitives and other extensions;
- explicit public-submission boundary so projects are only represented when their builders choose to share them.

Blueballs does not invent adoption, customer logos, integrations or partnerships. The showcase creates a place for real builder work to become discoverable when it exists.