### PR TITLE
Build the first Blueballs demand engine

### DIFF
--- a/.github/ISSUE_TEMPLATE/provider.yml
+++ b/.github/ISSUE_TEMPLATE/provider.yml
@@ -1,16 +1,18 @@
-name: Provider ecosystem
-description: Add, update or explore a provider listing, adapter or infrastructure connection.
+name: Provider partnership
+description: Explore an adapter, integration, launch, research collaboration or qualified-demand pilot with Blueballs.
 title: "[Provider] "
 body:
   - type: markdown
     attributes:
       value: |
-        ## Connect infrastructure to Blueballs
-        Use this form for provider-directory updates, adapter work, compatibility discussions or infrastructure collaboration.
+        ## Work with Blueballs
+        Use this form if you represent financial infrastructure and want to explore a deeper relationship with the Blueballs ecosystem.
 
-        A Blueballs listing does not imply a partnership or production integration. Relationship and technical status remain explicit in the directory.
+        Directory participation is not pay-to-rank. Commercial relationships, sponsored work and technical status are labelled separately, and payment does not buy an organic ranking or technical verification.
 
-        This is a public GitHub issue. Do not include credentials, customer information, confidential commercial terms or other sensitive data.
+        If you only need to claim, correct or add a provider profile, use the **Claim or update a provider profile** form instead.
+
+        This is a public GitHub issue. Keep the first brief non-confidential. Do not include credentials, customer information, pricing terms or other sensitive commercial information.
   - type: input
     id: provider
     attributes:
@@ -21,20 +23,22 @@ body:
   - type: dropdown
     id: request
     attributes:
-      label: What are you proposing?
+      label: What would you like to explore?
       options:
-        - Add or update a directory listing
-        - Build a Blueballs adapter
-        - Document compatibility
-        - Explore an integration
-        - Correct provider information
+        - Build or improve a Blueballs adapter
+        - Document or test compatibility
+        - Create a reference implementation or Blueprint
+        - Launch or research collaboration
+        - Qualified builder-demand pilot
+        - Design or implementation partnership
+        - Other infrastructure collaboration
     validations:
       required: true
   - type: textarea
     id: capabilities
     attributes:
-      label: Capabilities
-      description: Accounts, rails, cards, KYC/KYB, custody, stablecoins, FX, treasury, reconciliation or other infrastructure.
+      label: Infrastructure capabilities
+      description: Accounts, sponsor banking, rails, cards, KYC/KYB, custody, stablecoins, FX, treasury, reconciliation or other infrastructure.
     validations:
       required: true
   - type: input
@@ -50,14 +54,23 @@ body:
     validations:
       required: true
   - type: textarea
-    id: notes
+    id: outcome
     attributes:
-      label: What should Blueballs evaluate?
-      placeholder: Describe the listing, compatibility or adapter opportunity.
+      label: What outcome are you trying to achieve?
+      description: Keep this public-safe. For example, reach builders in a target market, create a reference integration, or validate compatibility with a Blueballs product flow.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Useful public links
+      description: Product pages, API documentation, market coverage or other public information Blueballs should review.
   - type: checkboxes
     id: public
     attributes:
       label: Public issue acknowledgement
       options:
-        - label: I have not included secrets, customer data or confidential information.
+        - label: I have not included secrets, customer data, private contact details, pricing terms or confidential information.
+          required: true
+        - label: I understand that commercial participation does not buy organic ranking or technical verification.
           required: true

--- a/.github/ISSUE_TEMPLATE/provider_claim.yml
+++ b/.github/ISSUE_TEMPLATE/provider_claim.yml
@@ -1,0 +1,82 @@
+name: Claim or update a provider profile
+description: Claim, correct or enrich a financial-infrastructure profile in the Blueballs directory.
+title: "[Provider profile] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Claim or update your Blueballs profile
+        Blueballs maintains an independent directory of financial-infrastructure providers for builders researching their stack.
+
+        Claiming a profile lets a provider help keep factual information current. **A claimed profile is not a paid ranking, partnership, endorsement or technical verification.** Commercial relationships and technical status are labelled separately.
+
+        This issue is public. Do not post credentials, private contact details, customer information or confidential commercial terms.
+  - type: input
+    id: provider
+    attributes:
+      label: Provider name
+      placeholder: Company or infrastructure project
+    validations:
+      required: true
+  - type: dropdown
+    id: request
+    attributes:
+      label: Request
+      options:
+        - Claim an existing profile
+        - Correct an existing profile
+        - Add a provider that is missing
+        - Add or update capabilities and market coverage
+    validations:
+      required: true
+  - type: input
+    id: official
+    attributes:
+      label: Official provider URL
+      placeholder: https://provider.example
+    validations:
+      required: true
+  - type: input
+    id: docs
+    attributes:
+      label: Official technical documentation
+      placeholder: https://docs.provider.example
+  - type: textarea
+    id: capabilities
+    attributes:
+      label: Capabilities to list
+      description: Accounts, sponsor banking, KYC/KYB, payment rails, cards, custody, stablecoins, FX, open banking, treasury, reconciliation or other infrastructure.
+    validations:
+      required: true
+  - type: textarea
+    id: markets
+    attributes:
+      label: Markets and availability
+      description: List the regions or countries that should be reflected, with official source links where practical.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Source links
+      description: Provide official pages Blueballs can use to verify the requested changes.
+      placeholder: |
+        Product: https://...
+        Coverage: https://...
+        Sandbox: https://...
+    validations:
+      required: true
+  - type: textarea
+    id: representation
+    attributes:
+      label: Provider representation
+      description: If you represent the provider, link to a public company profile that identifies you or state that domain-email verification is available privately. Do not publish a private email address here.
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: I understand that claiming a profile does not buy an organic ranking or technical verification.
+          required: true
+        - label: I have not included secrets, customer data, private contact details or confidential information.
+          required: true

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "preview:upload": "pnpm build && wrangler versions upload -c wrangler.jsonc",
     "test:api": "pnpm --dir apps/api test:ci",
     "test:fx": "node scripts/test-fx.mjs",
-    "test:workers": "pnpm --dir packages/sqlite-compat test:ci && node --test workers/site/edge-routing.test.js && vitest run --config vitest.config.mts && vitest run --config vitest.api.config.mts && vitest run --config vitest.fx.config.mts",
+    "test:workers": "pnpm --dir packages/sqlite-compat test:ci && node --test workers/site/edge-routing.test.js workers/site/growth-events.test.js && vitest run --config vitest.config.mts && vitest run --config vitest.api.config.mts && vitest run --config vitest.fx.config.mts",
     "verify": "node scripts/release-proof.mjs",
     "verify:release": "node scripts/release-proof.mjs --require-clean --full",
     "verify:raw": "node scripts/verify.mjs",

--- a/src/EcosystemPage.tsx
+++ b/src/EcosystemPage.tsx
@@ -1,15 +1,40 @@
-import { useMemo, useState, type ChangeEvent } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type ChangeEvent,
+} from "react";
+import { trackGrowthEvent } from "./growth/events";
 import { CATEGORIES, CATEGORY_MAP, PROVIDERS } from "./ecosystem/data";
 import CategoryMap, { type FilterId } from "./ecosystem/CategoryMap";
 import ProviderCard from "./ecosystem/ProviderCard";
+import type { Provider } from "./ecosystem/types";
 import "./EcosystemPage.css";
+
 const MONO = "'IBM Plex Mono', monospace";
+const REPO = "https://github.com/Josh-Gi3r/blueballs";
+const SHORTLIST_KEY = "blueballs_provider_shortlist";
+const MAX_SHORTLIST = 3;
 type EcosystemPageProps = { onNavigate: (path: string) => void };
+
 const FILLER_COPY = [
   ["DIRECTORY", "Provider landscape."],
   ["OPEN SOURCE", "Free to fork and self-host."],
   ["SOURCES", "Links to official websites."],
 ] as const;
+
+function initialShortlist() {
+  if (typeof window === "undefined") return [] as string[];
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(SHORTLIST_KEY) || "[]");
+    if (!Array.isArray(parsed)) return [];
+    const valid = new Set(PROVIDERS.map((provider) => provider.id));
+    return parsed.filter((id): id is string => typeof id === "string" && valid.has(id)).slice(0, MAX_SHORTLIST);
+  } catch {
+    return [] as string[];
+  }
+}
+
 function EcosystemFillers({
   count,
   columns,
@@ -37,14 +62,106 @@ function EcosystemFillers({
     </>
   );
 }
+
+function ComparePanel({
+  providers,
+  onClose,
+  onNavigate,
+}: {
+  providers: Provider[];
+  onClose: () => void;
+  onNavigate: (path: string) => void;
+}) {
+  return (
+    <section className="eco-compare-panel" aria-label="Provider comparison">
+      <div className="eco-compare-head">
+        <div>
+          <span>SHORTLIST COMPARISON</span>
+          <h2>Compare the infrastructure behind your product.</h2>
+          <p>
+            Blueballs keeps factual provider data separate from commercial
+            relationships. Compare the current directory evidence, then verify
+            final availability with each provider.
+          </p>
+        </div>
+        <button type="button" onClick={onClose}>Close comparison</button>
+      </div>
+      <div className="eco-compare-grid">
+        {providers.map((provider) => (
+          <article key={provider.id}>
+            <span>{CATEGORY_MAP[provider.categories[0]].label}</span>
+            <h3>{provider.name}</h3>
+            <p>{provider.provides}</p>
+            <dl>
+              <div><dt>Access</dt><dd>{provider.access}</dd></div>
+              <div><dt>Sandbox</dt><dd>{provider.sandbox}</dd></div>
+              <div><dt>Technical</dt><dd>{provider.technicalStatus}</dd></div>
+              <div><dt>Regions</dt><dd>{provider.regions.join(" · ")}</dd></div>
+              <div><dt>Capabilities</dt><dd>{provider.capabilities.join(" · ")}</dd></div>
+            </dl>
+            <div className="eco-compare-links">
+              <a
+                href={provider.docsUrl}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() => trackGrowthEvent("provider_outbound", { provider: provider.id, destination: "docs", context: "compare" })}
+              >
+                Technical docs ↗
+              </a>
+              <a
+                href={provider.url}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() => trackGrowthEvent("provider_outbound", { provider: provider.id, destination: "website", context: "compare" })}
+              >
+                Company ↗
+              </a>
+            </div>
+          </article>
+        ))}
+      </div>
+      <div className="eco-compare-commercial">
+        <div>
+          <span>BUILD THE STACK</span>
+          <strong>Need help turning the shortlist into an implementation?</strong>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            trackGrowthEvent("commercial_cta", { source: "provider_compare", providers: providers.length });
+            onNavigate("/contact");
+          }}
+        >
+          Build with Blueballs →
+        </button>
+      </div>
+    </section>
+  );
+}
+
 export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
   const [active, setActive] = useState<FilterId>("all");
   const [query, setQuery] = useState("");
+  const [shortlist, setShortlist] = useState<string[]>(initialShortlist);
+  const [showCompare, setShowCompare] = useState(false);
+  const [notice, setNotice] = useState("");
+
+  useEffect(() => {
+    trackGrowthEvent("provider_directory_view", { providers: PROVIDERS.length });
+  }, []);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(SHORTLIST_KEY, JSON.stringify(shortlist));
+    } catch {
+      // The shortlist still works for the current session if storage is blocked.
+    }
+  }, [shortlist]);
+
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     return PROVIDERS.filter((provider) => {
-      const categoryMatch =
-        active === "all" || provider.categories.includes(active);
+      const categoryMatch = active === "all" || provider.categories.includes(active);
       if (!categoryMatch) return false;
       if (!q) return true;
       return [
@@ -62,79 +179,158 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
         .includes(q);
     });
   }, [active, query]);
+
   const selectedCategory = active === "all" ? null : CATEGORY_MAP[active];
+  const shortlistedProviders = useMemo(
+    () => shortlist.flatMap((id) => {
+      const provider = PROVIDERS.find((candidate) => candidate.id === id);
+      return provider ? [provider] : [];
+    }),
+    [shortlist],
+  );
+
+  const toggleShortlist = (provider: Provider) => {
+    const selected = shortlist.includes(provider.id);
+    if (!selected && shortlist.length >= MAX_SHORTLIST) {
+      setNotice(`Compare up to ${MAX_SHORTLIST} providers at a time.`);
+      return;
+    }
+    const next = selected
+      ? shortlist.filter((id) => id !== provider.id)
+      : [...shortlist, provider.id];
+    setShortlist(next);
+    if (next.length < 2) setShowCompare(false);
+    setNotice("");
+    trackGrowthEvent(selected ? "provider_unshortlist" : "provider_shortlist", {
+      provider: provider.id,
+      category: provider.categories[0],
+      shortlist_size: next.length,
+    });
+  };
+
+  const claimDirectoryHref = `${REPO}/issues/new?template=provider_claim.yml`;
+
   return (
     <div className="eco-page">
       <section className="eco-hero">
         <div className="eco-hero-copy">
-          <div className="eco-eyebrow">PROVIDER DIRECTORY</div>
+          <div className="eco-eyebrow">FINANCIAL INFRASTRUCTURE DIRECTORY</div>
           <h1>
             <span>Find the services</span>
             <span>your product needs.</span>
           </h1>
           <p>
-            Compare companies that provide banking, identity, payments, cards,
-            custody, liquidity and other financial infrastructure. Blueballs is
-            the software layer; you choose the providers behind your product.
+            Research, shortlist and compare companies across banking, identity,
+            payments, cards, custody, stablecoins and FX. Blueballs stays
+            provider-neutral; you decide what powers your product.
           </p>
           <div className="eco-hero-actions">
             <button
               type="button"
-              onClick={() =>
-                document
-                  .getElementById("eco-directory")
-                  ?.scrollIntoView({ behavior: "smooth" })
-              }
+              onClick={() => document.getElementById("eco-directory")?.scrollIntoView({ behavior: "smooth" })}
             >
               Browse the directory
+            </button>
+            <a
+              href={claimDirectoryHref}
+              target="_blank"
+              rel="noreferrer"
+              className="secondary"
+              onClick={() => trackGrowthEvent("provider_claim_start", { provider: "unselected", source: "directory_hero" })}
+            >
+              Claim a provider profile
+            </a>
+          </div>
+          <div className="eco-hero-guide">
+            <div>
+              <span>DISCOVER</span>
+              <strong>Find infrastructure by capability and market.</strong>
+            </div>
+            <div>
+              <span>DECIDE</span>
+              <strong>Shortlist up to three providers and compare them.</strong>
+            </div>
+            <div>
+              <span>BUILD</span>
+              <strong>Connect the providers you choose behind Blueballs.</strong>
+            </div>
+          </div>
+        </div>
+        <CategoryMap active={active} setActive={(next) => {
+          setActive(next);
+          trackGrowthEvent("provider_filter", { category: next });
+        }} />
+      </section>
+
+      {shortlistedProviders.length > 0 && (
+        <section className="eco-shortlist-bar" aria-live="polite">
+          <div>
+            <span>YOUR SHORTLIST</span>
+            <strong>{shortlistedProviders.map((provider) => provider.name).join(" · ")}</strong>
+            {notice && <small>{notice}</small>}
+          </div>
+          <div>
+            <button
+              type="button"
+              disabled={shortlistedProviders.length < 2}
+              onClick={() => {
+                setShowCompare(true);
+                trackGrowthEvent("provider_compare", {
+                  providers: shortlistedProviders.length,
+                  provider_ids: shortlistedProviders.map((provider) => provider.id).join(","),
+                });
+              }}
+            >
+              Compare {shortlistedProviders.length > 1 ? shortlistedProviders.length : "providers"}
             </button>
             <button
               type="button"
               className="secondary"
-              onClick={() => onNavigate("/developers")}
+              onClick={() => {
+                setShortlist([]);
+                setShowCompare(false);
+                setNotice("");
+              }}
             >
-              See Blueballs APIs
+              Clear
             </button>
           </div>
-          <div className="eco-hero-guide">
-            <div>
-              <span>BLUEBALLS</span>
-              <strong>Run and change the open-source software yourself.</strong>
-            </div>
-            <div>
-              <span>BUILD</span>
-              <strong>Use the sandbox while you develop your product.</strong>
-            </div>
-            <div>
-              <span>PROVIDERS</span>
-              <strong>
-                Connect the banking and financial services you need.
-              </strong>
-            </div>
-          </div>
-        </div>
-        <CategoryMap active={active} setActive={setActive} />
-      </section>
+        </section>
+      )}
+
+      {showCompare && shortlistedProviders.length > 1 && (
+        <ComparePanel
+          providers={shortlistedProviders}
+          onClose={() => setShowCompare(false)}
+          onNavigate={onNavigate}
+        />
+      )}
+
       <section id="eco-directory" className="eco-directory">
         <div className="eco-directory-head">
           <div>
             <span>PROVIDER DIRECTORY</span>
-            <h2>
-              {selectedCategory ? selectedCategory.label : "Browse by service."}
-            </h2>
+            <h2>{selectedCategory ? selectedCategory.label : "Browse by service."}</h2>
             <p>
               {selectedCategory
                 ? selectedCategory.description
-                : "Filter by service or region, then go directly to the provider to see whether it fits your product."}
+                : "Filter by service or region, shortlist the providers that fit, then compare the evidence before you integrate."}
             </p>
           </div>
           <label className="eco-search">
             <span>SEARCH</span>
             <input
               value={query}
-              onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                setQuery(event.target.value)
-              }
+              onChange={(event: ChangeEvent<HTMLInputElement>) => setQuery(event.target.value)}
+              onBlur={() => {
+                if (query.trim()) {
+                  trackGrowthEvent("provider_search", {
+                    query_length: query.trim().length,
+                    results: filtered.length,
+                    category: active,
+                  });
+                }
+              }}
               placeholder="Provider, capability or region…"
             />
           </label>
@@ -143,7 +339,10 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
           <button
             type="button"
             className={active === "all" ? "active" : ""}
-            onClick={() => setActive("all")}
+            onClick={() => {
+              setActive("all");
+              trackGrowthEvent("provider_filter", { category: "all" });
+            }}
           >
             <b>All providers</b>
             <span>{PROVIDERS.length}</span>
@@ -153,16 +352,13 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
               key={category.id}
               type="button"
               className={active === category.id ? "active" : ""}
-              onClick={() => setActive(category.id)}
+              onClick={() => {
+                setActive(category.id);
+                trackGrowthEvent("provider_filter", { category: category.id });
+              }}
             >
               <b>{category.label}</b>
-              <span>
-                {
-                  PROVIDERS.filter((provider) =>
-                    provider.categories.includes(category.id),
-                  ).length
-                }
-              </span>
+              <span>{PROVIDERS.filter((provider) => provider.categories.includes(category.id)).length}</span>
             </button>
           ))}
         </div>
@@ -175,66 +371,72 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
             <div>
               <span>RELATED BLUEBALLS MODULES</span>
               <div>
-                {selectedCategory.blueballs.map((module) => (
-                  <b key={module}>{module}</b>
-                ))}
+                {selectedCategory.blueballs.map((module) => <b key={module}>{module}</b>)}
               </div>
             </div>
           </div>
         )}
         <div className="eco-results-line">
-          <span>
-            {filtered.length} {filtered.length === 1 ? "listing" : "listings"}
-          </span>
-          <span>
-            Reviewed against official provider information · 20 Aug 2026
-          </span>
+          <span>{filtered.length} {filtered.length === 1 ? "listing" : "listings"}</span>
+          <span>Reviewed against official provider information · 20 Aug 2026</span>
         </div>
         <div className="eco-provider-grid">
           {filtered.map((provider) => (
-            <ProviderCard provider={provider} key={provider.id} />
+            <ProviderCard
+              provider={provider}
+              key={provider.id}
+              selected={shortlist.includes(provider.id)}
+              onToggleShortlist={toggleShortlist}
+            />
           ))}
           <EcosystemFillers count={filtered.length} columns={3} />
           <EcosystemFillers count={filtered.length} columns={2} />
         </div>
         {filtered.length === 0 && (
-          <div className="eco-empty">
-            No providers match “{query}” in this category.
-          </div>
+          <div className="eco-empty">No providers match “{query}” in this category.</div>
         )}
       </section>
+
       <section className="eco-bottom">
         <div>
-          <span>CONNECT A PROVIDER</span>
-          <h2>
-            Keep your product API stable while the provider changes underneath.
-          </h2>
+          <span>INFRASTRUCTURE PROVIDERS</span>
+          <h2>Be discoverable where financial products are being designed.</h2>
           <p>
-            Blueballs adapters map external providers to the interfaces used by
-            your product. Build or change an adapter, test it in the sandbox,
-            then add credentials from the provider you choose.
+            Claim or correct your profile, contribute an adapter, or talk to
+            Blueballs about launches, research and qualified builder demand.
+            Commercial relationships are labelled and never change organic
+            technical status.
           </p>
         </div>
         <div className="eco-bottom-actions">
-          <button type="button" onClick={() => onNavigate("/developers")}>
-            View API reference
-          </button>
+          <a
+            href={claimDirectoryHref}
+            target="_blank"
+            rel="noreferrer"
+            onClick={() => trackGrowthEvent("provider_claim_start", { provider: "unselected", source: "directory_bottom" })}
+          >
+            Claim your profile
+          </a>
           <button
             type="button"
             className="secondary"
-            onClick={() => onNavigate("/contact")}
+            onClick={() => {
+              trackGrowthEvent("provider_partnership_start", { source: "directory_bottom" });
+              onNavigate("/contact");
+            }}
           >
-            Build an adapter
+            Work with Blueballs
           </button>
         </div>
       </section>
       <div className="eco-disclaimer">
-        <span style={{ fontFamily: MONO }}>ABOUT THIS DIRECTORY</span>
+        <span style={{ fontFamily: MONO }}>HOW BLUEBALLS RANKS</span>
         <p>
-          Listings link to official provider sources and show relationship and
-          technical status explicitly. Access and sandbox details were reviewed
-          on 20 Aug 2026. Products and availability change, so check the
-          provider's current documentation before building.
+          Directory data links to official provider sources. Commercial
+          relationships, if any, are labelled separately from technical status.
+          Paid participation does not buy an organic ranking or a technical
+          verification. Provider availability changes, so confirm current terms
+          and coverage directly with the provider before building.
         </p>
       </div>
     </div>

--- a/src/EcosystemPage.tsx
+++ b/src/EcosystemPage.tsx
@@ -26,10 +26,16 @@ const FILLER_COPY = [
 function initialShortlist() {
   if (typeof window === "undefined") return [] as string[];
   try {
-    const parsed = JSON.parse(window.localStorage.getItem(SHORTLIST_KEY) || "[]");
+    const parsed = JSON.parse(
+      window.localStorage.getItem(SHORTLIST_KEY) || "[]",
+    );
     if (!Array.isArray(parsed)) return [];
     const valid = new Set(PROVIDERS.map((provider) => provider.id));
-    return parsed.filter((id): id is string => typeof id === "string" && valid.has(id)).slice(0, MAX_SHORTLIST);
+    return parsed
+      .filter(
+        (id): id is string => typeof id === "string" && valid.has(id),
+      )
+      .slice(0, MAX_SHORTLIST);
   } catch {
     return [] as string[];
   }
@@ -84,7 +90,9 @@ function ComparePanel({
             final availability with each provider.
           </p>
         </div>
-        <button type="button" onClick={onClose}>Close comparison</button>
+        <button type="button" onClick={onClose}>
+          Close comparison
+        </button>
       </div>
       <div className="eco-compare-grid">
         {providers.map((provider) => (
@@ -93,18 +101,39 @@ function ComparePanel({
             <h3>{provider.name}</h3>
             <p>{provider.provides}</p>
             <dl>
-              <div><dt>Access</dt><dd>{provider.access}</dd></div>
-              <div><dt>Sandbox</dt><dd>{provider.sandbox}</dd></div>
-              <div><dt>Technical</dt><dd>{provider.technicalStatus}</dd></div>
-              <div><dt>Regions</dt><dd>{provider.regions.join(" · ")}</dd></div>
-              <div><dt>Capabilities</dt><dd>{provider.capabilities.join(" · ")}</dd></div>
+              <div>
+                <dt>Access</dt>
+                <dd>{provider.access}</dd>
+              </div>
+              <div>
+                <dt>Sandbox</dt>
+                <dd>{provider.sandbox}</dd>
+              </div>
+              <div>
+                <dt>Technical</dt>
+                <dd>{provider.technicalStatus}</dd>
+              </div>
+              <div>
+                <dt>Regions</dt>
+                <dd>{provider.regions.join(" · ")}</dd>
+              </div>
+              <div>
+                <dt>Capabilities</dt>
+                <dd>{provider.capabilities.join(" · ")}</dd>
+              </div>
             </dl>
             <div className="eco-compare-links">
               <a
                 href={provider.docsUrl}
                 target="_blank"
                 rel="noreferrer"
-                onClick={() => trackGrowthEvent("provider_outbound", { provider: provider.id, destination: "docs", context: "compare" })}
+                onClick={() =>
+                  trackGrowthEvent("provider_outbound", {
+                    provider: provider.id,
+                    destination: "docs",
+                    context: "compare",
+                  })
+                }
               >
                 Technical docs ↗
               </a>
@@ -112,7 +141,13 @@ function ComparePanel({
                 href={provider.url}
                 target="_blank"
                 rel="noreferrer"
-                onClick={() => trackGrowthEvent("provider_outbound", { provider: provider.id, destination: "website", context: "compare" })}
+                onClick={() =>
+                  trackGrowthEvent("provider_outbound", {
+                    provider: provider.id,
+                    destination: "website",
+                    context: "compare",
+                  })
+                }
               >
                 Company ↗
               </a>
@@ -128,7 +163,10 @@ function ComparePanel({
         <button
           type="button"
           onClick={() => {
-            trackGrowthEvent("commercial_cta", { source: "provider_compare", providers: providers.length });
+            trackGrowthEvent("commercial_cta", {
+              source: "provider_compare",
+              providers: providers.length,
+            });
             onNavigate("/contact");
           }}
         >
@@ -161,7 +199,8 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     return PROVIDERS.filter((provider) => {
-      const categoryMatch = active === "all" || provider.categories.includes(active);
+      const categoryMatch =
+        active === "all" || provider.categories.includes(active);
       if (!categoryMatch) return false;
       if (!q) return true;
       return [
@@ -182,10 +221,11 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
 
   const selectedCategory = active === "all" ? null : CATEGORY_MAP[active];
   const shortlistedProviders = useMemo(
-    () => shortlist.flatMap((id) => {
-      const provider = PROVIDERS.find((candidate) => candidate.id === id);
-      return provider ? [provider] : [];
-    }),
+    () =>
+      shortlist.flatMap((id) => {
+        const provider = PROVIDERS.find((candidate) => candidate.id === id);
+        return provider ? [provider] : [];
+      }),
     [shortlist],
   );
 
@@ -227,7 +267,11 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
           <div className="eco-hero-actions">
             <button
               type="button"
-              onClick={() => document.getElementById("eco-directory")?.scrollIntoView({ behavior: "smooth" })}
+              onClick={() =>
+                document
+                  .getElementById("eco-directory")
+                  ?.scrollIntoView({ behavior: "smooth" })
+              }
             >
               Browse the directory
             </button>
@@ -236,7 +280,12 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
               target="_blank"
               rel="noreferrer"
               className="secondary"
-              onClick={() => trackGrowthEvent("provider_claim_start", { provider: "unselected", source: "directory_hero" })}
+              onClick={() =>
+                trackGrowthEvent("provider_claim_start", {
+                  provider: "unselected",
+                  source: "directory_hero",
+                })
+              }
             >
               Claim a provider profile
             </a>
@@ -256,17 +305,24 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
             </div>
           </div>
         </div>
-        <CategoryMap active={active} setActive={(next) => {
-          setActive(next);
-          trackGrowthEvent("provider_filter", { category: next });
-        }} />
+        <CategoryMap
+          active={active}
+          setActive={(next) => {
+            setActive(next);
+            trackGrowthEvent("provider_filter", { category: next });
+          }}
+        />
       </section>
 
       {shortlistedProviders.length > 0 && (
         <section className="eco-shortlist-bar" aria-live="polite">
           <div>
             <span>YOUR SHORTLIST</span>
-            <strong>{shortlistedProviders.map((provider) => provider.name).join(" · ")}</strong>
+            <strong>
+              {shortlistedProviders
+                .map((provider) => provider.name)
+                .join(" · ")}
+            </strong>
             {notice && <small>{notice}</small>}
           </div>
           <div>
@@ -277,11 +333,16 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
                 setShowCompare(true);
                 trackGrowthEvent("provider_compare", {
                   providers: shortlistedProviders.length,
-                  provider_ids: shortlistedProviders.map((provider) => provider.id).join(","),
+                  provider_ids: shortlistedProviders
+                    .map((provider) => provider.id)
+                    .join(","),
                 });
               }}
             >
-              Compare {shortlistedProviders.length > 1 ? shortlistedProviders.length : "providers"}
+              Compare{" "}
+              {shortlistedProviders.length > 1
+                ? shortlistedProviders.length
+                : "providers"}
             </button>
             <button
               type="button"
@@ -310,7 +371,9 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
         <div className="eco-directory-head">
           <div>
             <span>PROVIDER DIRECTORY</span>
-            <h2>{selectedCategory ? selectedCategory.label : "Browse by service."}</h2>
+            <h2>
+              {selectedCategory ? selectedCategory.label : "Browse by service."}
+            </h2>
             <p>
               {selectedCategory
                 ? selectedCategory.description
@@ -321,7 +384,9 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
             <span>SEARCH</span>
             <input
               value={query}
-              onChange={(event: ChangeEvent<HTMLInputElement>) => setQuery(event.target.value)}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                setQuery(event.target.value)
+              }
               onBlur={() => {
                 if (query.trim()) {
                   trackGrowthEvent("provider_search", {
@@ -358,7 +423,13 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
               }}
             >
               <b>{category.label}</b>
-              <span>{PROVIDERS.filter((provider) => provider.categories.includes(category.id)).length}</span>
+              <span>
+                {
+                  PROVIDERS.filter((provider) =>
+                    provider.categories.includes(category.id),
+                  ).length
+                }
+              </span>
             </button>
           ))}
         </div>
@@ -371,13 +442,17 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
             <div>
               <span>RELATED BLUEBALLS MODULES</span>
               <div>
-                {selectedCategory.blueballs.map((module) => <b key={module}>{module}</b>)}
+                {selectedCategory.blueballs.map((module) => (
+                  <b key={module}>{module}</b>
+                ))}
               </div>
             </div>
           </div>
         )}
         <div className="eco-results-line">
-          <span>{filtered.length} {filtered.length === 1 ? "listing" : "listings"}</span>
+          <span>
+            {filtered.length} {filtered.length === 1 ? "listing" : "listings"}
+          </span>
           <span>Reviewed against official provider information · 20 Aug 2026</span>
         </div>
         <div className="eco-provider-grid">
@@ -393,7 +468,9 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
           <EcosystemFillers count={filtered.length} columns={2} />
         </div>
         {filtered.length === 0 && (
-          <div className="eco-empty">No providers match “{query}” in this category.</div>
+          <div className="eco-empty">
+            No providers match “{query}” in this category.
+          </div>
         )}
       </section>
 
@@ -413,7 +490,12 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
             href={claimDirectoryHref}
             target="_blank"
             rel="noreferrer"
-            onClick={() => trackGrowthEvent("provider_claim_start", { provider: "unselected", source: "directory_bottom" })}
+            onClick={() =>
+              trackGrowthEvent("provider_claim_start", {
+                provider: "unselected",
+                source: "directory_bottom",
+              })
+            }
           >
             Claim your profile
           </a>
@@ -421,7 +503,9 @@ export default function EcosystemPage({ onNavigate }: EcosystemPageProps) {
             type="button"
             className="secondary"
             onClick={() => {
-              trackGrowthEvent("provider_partnership_start", { source: "directory_bottom" });
+              trackGrowthEvent("provider_partnership_start", {
+                source: "directory_bottom",
+              });
               onNavigate("/contact");
             }}
           >

--- a/src/ecosystem/ProviderCard.tsx
+++ b/src/ecosystem/ProviderCard.tsx
@@ -1,5 +1,8 @@
 import { useState } from "react";
+import { trackGrowthEvent } from "../growth/events";
 import { CATEGORY_MAP, type Provider } from "./data";
+
+const REPO = "https://github.com/Josh-Gi3r/blueballs";
 
 function domainFor(url: string) {
   try {
@@ -35,10 +38,30 @@ function ProviderLogo({ provider }: { provider: Provider }) {
   );
 }
 
-export default function ProviderCard({ provider }: { provider: Provider }) {
+type ProviderCardProps = {
+  provider: Provider;
+  selected: boolean;
+  onToggleShortlist: (provider: Provider) => void;
+};
+
+export default function ProviderCard({
+  provider,
+  selected,
+  onToggleShortlist,
+}: ProviderCardProps) {
   const primary = CATEGORY_MAP[provider.categories[0]];
+  const claimHref = `${REPO}/issues/new?template=provider_claim.yml&title=${encodeURIComponent(
+    `[Provider profile] ${provider.name}`,
+  )}`;
+  const trackOutbound = (destination: "website" | "docs") =>
+    trackGrowthEvent("provider_outbound", {
+      provider: provider.id,
+      destination,
+      category: provider.categories[0],
+    });
+
   return (
-    <article className="eco-provider-card">
+    <article className={`eco-provider-card${selected ? " is-shortlisted" : ""}`}>
       <div className="eco-provider-top">
         <a
           className="eco-provider-brand"
@@ -46,6 +69,7 @@ export default function ProviderCard({ provider }: { provider: Provider }) {
           target="_blank"
           rel="noreferrer"
           aria-label={`${provider.name} official website`}
+          onClick={() => trackOutbound("website")}
         >
           <ProviderLogo provider={provider} />
           <div>
@@ -93,11 +117,41 @@ export default function ProviderCard({ provider }: { provider: Provider }) {
           <b>{provider.regions.join(" · ")}</b>
         </div>
       </div>
+      <div className="eco-provider-decision-actions">
+        <button
+          type="button"
+          className={selected ? "selected" : ""}
+          aria-pressed={selected}
+          onClick={() => onToggleShortlist(provider)}
+        >
+          {selected ? "Shortlisted ✓" : "Add to shortlist"}
+        </button>
+        <a
+          href={claimHref}
+          target="_blank"
+          rel="noreferrer"
+          onClick={() =>
+            trackGrowthEvent("provider_claim_start", { provider: provider.id })
+          }
+        >
+          Claim / update profile
+        </a>
+      </div>
       <div className="eco-provider-links">
-        <a href={provider.docsUrl} target="_blank" rel="noreferrer">
+        <a
+          href={provider.docsUrl}
+          target="_blank"
+          rel="noreferrer"
+          onClick={() => trackOutbound("docs")}
+        >
           Technical docs <span>↗</span>
         </a>
-        <a href={provider.url} target="_blank" rel="noreferrer">
+        <a
+          href={provider.url}
+          target="_blank"
+          rel="noreferrer"
+          onClick={() => trackOutbound("website")}
+        >
           Company <span>↗</span>
         </a>
       </div>

--- a/src/ecosystem/ProviderCard.tsx
+++ b/src/ecosystem/ProviderCard.tsx
@@ -61,7 +61,9 @@ export default function ProviderCard({
     });
 
   return (
-    <article className={`eco-provider-card${selected ? " is-shortlisted" : ""}`}>
+    <article
+      className={`eco-provider-card${selected ? " is-shortlisted" : ""}`}
+    >
       <div className="eco-provider-top">
         <a
           className="eco-provider-brand"

--- a/src/ecosystem/eco-base.css
+++ b/src/ecosystem/eco-base.css
@@ -97,7 +97,9 @@
   margin-top: 14px;
 }
 .eco-hero-actions button,
-.eco-bottom-actions button {
+.eco-hero-actions a,
+.eco-bottom-actions button,
+.eco-bottom-actions a {
   border: 1px solid var(--eco-ink);
   background: var(--eco-ink);
   color: #fff;
@@ -105,9 +107,15 @@
   padding: 13px 18px;
   font-size: 13px;
   font-weight: 550;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
 }
 .eco-hero-actions button:hover,
-.eco-bottom-actions button:hover {
+.eco-hero-actions a:hover,
+.eco-bottom-actions button:hover,
+.eco-bottom-actions a:hover {
   background: var(--eco-blue);
   border-color: var(--eco-blue);
 }

--- a/src/ecosystem/eco-cards.css
+++ b/src/ecosystem/eco-cards.css
@@ -52,6 +52,11 @@
   box-shadow: 0 15px 32px rgba(50, 61, 104, 0.08);
   background: #fff;
 }
+.eco-provider-card.is-shortlisted {
+  border-color: #0647e8;
+  box-shadow: 0 0 0 1px rgba(6, 71, 232, 0.08);
+  background: #fff;
+}
 .eco-provider-featured {
   background: #fff;
 }
@@ -216,6 +221,38 @@
   white-space: normal;
   overflow-wrap: anywhere;
 }
+.eco-provider-decision-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 7px;
+  margin-top: 14px;
+}
+.eco-provider-decision-actions button,
+.eco-provider-decision-actions a {
+  min-height: 34px;
+  border: 1px solid #cfd5e3;
+  border-radius: 9px;
+  background: #fff;
+  color: #07144f;
+  font: 600 9px "IBM Plex Mono", monospace;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 8px 9px;
+  cursor: pointer;
+  text-decoration: none;
+}
+.eco-provider-decision-actions button:hover,
+.eco-provider-decision-actions a:hover {
+  border-color: #0647e8;
+  color: #0647e8;
+}
+.eco-provider-decision-actions button.selected {
+  background: #0647e8;
+  border-color: #0647e8;
+  color: #fff;
+}
 .eco-provider-links {
   margin-top: 12px;
   padding-top: 10px;
@@ -263,4 +300,10 @@
     8.5px "IBM Plex Mono",
     monospace;
   color: #7f899e;
+}
+
+@media (max-width: 560px) {
+  .eco-provider-decision-actions {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/ecosystem/eco-directory.css
+++ b/src/ecosystem/eco-directory.css
@@ -16,9 +16,7 @@
   gap: 4px;
 }
 .eco-search span {
-  font:
-    8px "IBM Plex Mono",
-    monospace;
+  font: 8px "IBM Plex Mono", monospace;
   letter-spacing: 0.12em;
   color: var(--eco-muted);
 }
@@ -30,6 +28,170 @@
   color: var(--eco-ink);
   width: 100%;
   min-width: 0;
+}
+.eco-shortlist-bar {
+  border: 1px solid #b9c4e8;
+  background: #eef3ff;
+  border-radius: 16px;
+  padding: 16px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.eco-shortlist-bar > div:first-child {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.eco-shortlist-bar span,
+.eco-compare-head span,
+.eco-compare-commercial span {
+  font: 9px "IBM Plex Mono", monospace;
+  letter-spacing: 0.15em;
+  color: #5265aa;
+}
+.eco-shortlist-bar strong {
+  font-size: 13px;
+  line-height: 1.45;
+}
+.eco-shortlist-bar small {
+  color: #a0402b;
+  font-size: 11px;
+}
+.eco-shortlist-bar > div:last-child {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.eco-shortlist-bar button,
+.eco-compare-head button,
+.eco-compare-commercial button {
+  border: 1px solid #07144f;
+  background: #07144f;
+  color: #fff;
+  border-radius: 9px;
+  padding: 10px 14px;
+  font-size: 11px;
+  font-weight: 600;
+}
+.eco-shortlist-bar button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.eco-shortlist-bar button.secondary,
+.eco-compare-head button {
+  background: #fff;
+  color: #07144f;
+  border-color: #bfc7d8;
+}
+.eco-compare-panel {
+  border: 1px solid #b9c4e8;
+  border-radius: 18px;
+  background: #fff;
+  padding: 28px;
+}
+.eco-compare-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+.eco-compare-head h2 {
+  font-size: clamp(28px, 4vw, 44px);
+  margin: 8px 0 10px;
+  max-width: 18ch;
+}
+.eco-compare-head p {
+  margin: 0;
+  color: var(--eco-copy);
+  max-width: 66ch;
+  line-height: 1.55;
+  font-size: 13px;
+}
+.eco-compare-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+.eco-compare-grid article {
+  border: 1px solid var(--eco-soft);
+  border-radius: 14px;
+  padding: 18px;
+  background: var(--eco-wash);
+}
+.eco-compare-grid article > span {
+  font: 9px "IBM Plex Mono", monospace;
+  letter-spacing: 0.12em;
+  color: #5265aa;
+}
+.eco-compare-grid h3 {
+  margin: 8px 0 10px;
+  font-size: 21px;
+}
+.eco-compare-grid p {
+  color: var(--eco-copy);
+  font-size: 12px;
+  line-height: 1.5;
+  min-height: 54px;
+}
+.eco-compare-grid dl {
+  margin: 16px 0 0;
+}
+.eco-compare-grid dl div {
+  padding: 8px 0;
+  border-top: 1px solid var(--eco-soft);
+}
+.eco-compare-grid dt {
+  font: 8px "IBM Plex Mono", monospace;
+  letter-spacing: 0.1em;
+  color: var(--eco-muted);
+  margin-bottom: 4px;
+}
+.eco-compare-grid dd {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.45;
+}
+.eco-compare-links {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+.eco-compare-links a {
+  color: #0647e8;
+  font-size: 10px;
+}
+.eco-compare-commercial {
+  margin-top: 14px;
+  border-radius: 13px;
+  padding: 16px 18px;
+  background: #07144f;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.eco-compare-commercial > div {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.eco-compare-commercial span {
+  color: #9faedc;
+}
+.eco-compare-commercial strong {
+  font-size: 14px;
+}
+.eco-compare-commercial button {
+  background: #fff;
+  color: #07144f;
+  border-color: #fff;
 }
 .eco-filter-row {
   display: flex;
@@ -54,9 +216,7 @@
   font-weight: 550;
 }
 .eco-filter-row button span {
-  font:
-    8.5px "IBM Plex Mono",
-    monospace;
+  font: 8.5px "IBM Plex Mono", monospace;
   color: var(--eco-muted);
   background: var(--eco-wash);
   border-radius: 999px;
@@ -97,9 +257,7 @@
   flex-wrap: wrap;
 }
 .eco-category-brief b {
-  font:
-    9px "IBM Plex Mono",
-    monospace;
+  font: 9px "IBM Plex Mono", monospace;
   background: #fff;
   border: 1px solid #dbe0eb;
   border-radius: 999px;
@@ -112,9 +270,7 @@
   gap: 16px;
   border-top: 1px solid var(--eco-soft);
   padding: 14px 2px;
-  font:
-    9.5px "IBM Plex Mono",
-    monospace;
+  font: 9.5px "IBM Plex Mono", monospace;
   color: var(--eco-muted);
 }
 .eco-provider-grid {
@@ -194,7 +350,8 @@
   .eco-featured-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-  .eco-provider-grid {
+  .eco-provider-grid,
+  .eco-compare-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -214,7 +371,8 @@
   .eco-hero-copy,
   .eco-featured,
   .eco-directory,
-  .eco-bottom {
+  .eco-bottom,
+  .eco-compare-panel {
     padding: 25px 20px;
   }
   .eco-hero-copy h1 {
@@ -235,12 +393,15 @@
   }
   .eco-featured-grid,
   .eco-provider-grid,
-  .eco-category-brief {
+  .eco-category-brief,
+  .eco-compare-grid {
     grid-template-columns: 1fr;
   }
   .eco-section-head,
-  .eco-directory-head {
+  .eco-directory-head,
+  .eco-compare-head {
     align-items: flex-start;
+    flex-direction: column;
   }
   .eco-provider-card {
     min-height: 250px;

--- a/src/growth/events.ts
+++ b/src/growth/events.ts
@@ -9,7 +9,8 @@ export type GrowthEventName =
   | "provider_claim_start"
   | "provider_partnership_start"
   | "builder_start"
-  | "commercial_cta";
+  | "commercial_cta"
+  | "commercial_contact_view";
 
 type EventValue = string | number | boolean | null;
 type EventProperties = Record<string, EventValue>;
@@ -68,11 +69,11 @@ export function trackGrowthEvent(
 
   try {
     if (navigator.sendBeacon) {
-      navigator.sendBeacon(
+      const queued = navigator.sendBeacon(
         "/api/events",
         new Blob([payload], { type: "application/json" }),
       );
-      return;
+      if (queued) return;
     }
     void fetch("/api/events", {
       method: "POST",

--- a/src/growth/events.ts
+++ b/src/growth/events.ts
@@ -1,0 +1,86 @@
+export type GrowthEventName =
+  | "provider_directory_view"
+  | "provider_filter"
+  | "provider_search"
+  | "provider_shortlist"
+  | "provider_unshortlist"
+  | "provider_compare"
+  | "provider_outbound"
+  | "provider_claim_start"
+  | "provider_partnership_start"
+  | "builder_start"
+  | "commercial_cta";
+
+type EventValue = string | number | boolean | null;
+type EventProperties = Record<string, EventValue>;
+
+const SESSION_KEY = "blueballs_growth_session";
+const FIRST_TOUCH_KEY = "blueballs_growth_first_touch";
+
+function sessionId() {
+  if (typeof window === "undefined") return "server";
+  try {
+    const existing = window.sessionStorage.getItem(SESSION_KEY);
+    if (existing) return existing;
+    const next =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `s-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    window.sessionStorage.setItem(SESSION_KEY, next);
+    return next;
+  } catch {
+    return "unavailable";
+  }
+}
+
+function attribution() {
+  if (typeof window === "undefined") return {};
+  const params = new URLSearchParams(window.location.search);
+  const current = {
+    source: params.get("utm_source") || "",
+    medium: params.get("utm_medium") || "",
+    campaign: params.get("utm_campaign") || "",
+  };
+  try {
+    const existing = window.sessionStorage.getItem(FIRST_TOUCH_KEY);
+    if (existing) return JSON.parse(existing) as typeof current;
+    if (current.source || current.medium || current.campaign) {
+      window.sessionStorage.setItem(FIRST_TOUCH_KEY, JSON.stringify(current));
+    }
+  } catch {
+    // Attribution must never interfere with the product experience.
+  }
+  return current;
+}
+
+export function trackGrowthEvent(
+  name: GrowthEventName,
+  properties: EventProperties = {},
+) {
+  if (typeof window === "undefined") return;
+  const payload = JSON.stringify({
+    name,
+    path: window.location.pathname,
+    session_id: sessionId(),
+    attribution: attribution(),
+    properties,
+  });
+
+  try {
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon(
+        "/api/events",
+        new Blob([payload], { type: "application/json" }),
+      );
+      return;
+    }
+    void fetch("/api/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: payload,
+      keepalive: true,
+    });
+  } catch {
+    // Growth measurement is deliberately best-effort and cannot block a user.
+  }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { trackGrowthEvent } from "./growth/events";
 
 /** Minimal history-API router. Real URLs so every screen is linkable,
  * refreshable and back-button friendly — no framework needed.
@@ -22,6 +23,14 @@ export function usePath(): [string, (p: string) => void] {
       window.scrollTo(0, 0);
       return;
     }
+
+    const sourcePath = window.location.pathname;
+    if (p === "/sandbox") {
+      trackGrowthEvent("builder_start", { source_path: sourcePath });
+    } else if (p === "/contact") {
+      trackGrowthEvent("commercial_cta", { source_path: sourcePath });
+    }
+
     window.history.pushState({}, "", p);
     window.dispatchEvent(new PopStateEvent("popstate"));
     window.scrollTo(0, 0);

--- a/src/router.ts
+++ b/src/router.ts
@@ -28,7 +28,7 @@ export function usePath(): [string, (p: string) => void] {
     if (p === "/sandbox") {
       trackGrowthEvent("builder_start", { source_path: sourcePath });
     } else if (p === "/contact") {
-      trackGrowthEvent("commercial_cta", { source_path: sourcePath });
+      trackGrowthEvent("commercial_contact_view", { source_path: sourcePath });
     }
 
     window.history.pushState({}, "", p);

--- a/workers/site/edge-routing.test.js
+++ b/workers/site/edge-routing.test.js
@@ -70,3 +70,14 @@ test("edge forwarding preserves caller credentials and never injects an operator
   // and x-api-key survive while Origin is removed for the internal service hop.
   assert.match(edgeSource, /env\.FX\.fetch\(internalRequest\(target,\s*\{\}\)\)/);
 });
+
+test("growth events are owned by the public site edge, not the banking API", () => {
+  assert.match(
+    edgeSource,
+    /import\s*\{\s*handleGrowthEvent\s*\}\s*from\s*["']\.\/growth-events\.js["']/,
+  );
+  assert.match(
+    edgeSource,
+    /url\.pathname\s*===\s*["']\/api\/events["'][\s\S]*?handleGrowthEvent\(request,\s*env\)/,
+  );
+});

--- a/workers/site/edge-routing.test.js
+++ b/workers/site/edge-routing.test.js
@@ -74,10 +74,20 @@ test("edge forwarding preserves caller credentials and never injects an operator
 test("growth events are owned by the public site edge, not the banking API", () => {
   assert.match(
     edgeSource,
-    /import\s*\{\s*handleGrowthEvent\s*\}\s*from\s*["']\.\/growth-events\.js["']/,
+    /import\s*\{[\s\S]*?handleGrowthEvent[\s\S]*?logServerGrowthEvent[\s\S]*?\}\s*from\s*["']\.\/growth-events\.js["']/,
   );
   assert.match(
     edgeSource,
     /url\.pathname\s*===\s*["']\/api\/events["'][\s\S]*?handleGrowthEvent\(request,\s*env\)/,
+  );
+});
+
+test("successful Builder lifecycle calls emit server-confirmed activation signals", () => {
+  assert.match(edgeSource, /builder_blueprint_created/);
+  assert.match(edgeSource, /builder_sandbox_provisioned/);
+  assert.match(edgeSource, /builder_test_payment/);
+  assert.match(
+    edgeSource,
+    /response\.ok\s*&&\s*growthEvent[\s\S]*?logServerGrowthEvent\(request,\s*env,\s*growthEvent/,
   );
 });

--- a/workers/site/growth-events.js
+++ b/workers/site/growth-events.js
@@ -13,11 +13,12 @@ const CLIENT_EVENTS = new Set([
   "commercial_contact_view",
 ]);
 
-const SERVER_EVENTS = new Set([
-  "builder_blueprint_created",
-  "builder_sandbox_provisioned",
-  "builder_test_payment",
+const SERVER_EVENT_PATHS = new Map([
+  ["builder_blueprint_created", "/v2/builder/projects"],
+  ["builder_sandbox_provisioned", "/v2/builder/projects/:id/provision"],
+  ["builder_test_payment", "/v2/builder/projects/:id/test-payments"],
 ]);
+const SERVER_EVENTS = new Set(SERVER_EVENT_PATHS.keys());
 
 const MAX_BODY_BYTES = 4096;
 const MAX_PROPERTIES = 12;
@@ -83,7 +84,7 @@ export function logServerGrowthEvent(request, env, name, properties = {}) {
   if (!SERVER_EVENTS.has(name)) return false;
   writeGrowthEvent(request, env, {
     name,
-    path: new URL(request.url).pathname,
+    path: SERVER_EVENT_PATHS.get(name),
     session_id: null,
     attribution: {},
     properties,

--- a/workers/site/growth-events.js
+++ b/workers/site/growth-events.js
@@ -47,12 +47,26 @@ function referrerHost(request) {
   }
 }
 
+function sameOrigin(request) {
+  const origin = request.headers.get("origin");
+  if (!origin) return true;
+  try {
+    return new URL(origin).origin === new URL(request.url).origin;
+  } catch {
+    return false;
+  }
+}
+
 export async function handleGrowthEvent(request, env) {
   if (request.method !== "POST") {
     return new Response(null, {
       status: 405,
       headers: { allow: "POST", "cache-control": "no-store" },
     });
+  }
+
+  if (!sameOrigin(request)) {
+    return Response.json({ error: "Cross-origin events are not accepted." }, { status: 403 });
   }
 
   const declared = Number(request.headers.get("content-length") || 0);

--- a/workers/site/growth-events.js
+++ b/workers/site/growth-events.js
@@ -1,4 +1,4 @@
-const ALLOWED_EVENTS = new Set([
+const CLIENT_EVENTS = new Set([
   "provider_directory_view",
   "provider_filter",
   "provider_search",
@@ -11,6 +11,12 @@ const ALLOWED_EVENTS = new Set([
   "builder_start",
   "commercial_cta",
   "commercial_contact_view",
+]);
+
+const SERVER_EVENTS = new Set([
+  "builder_blueprint_created",
+  "builder_sandbox_provisioned",
+  "builder_test_payment",
 ]);
 
 const MAX_BODY_BYTES = 4096;
@@ -57,6 +63,34 @@ function sameOrigin(request) {
   }
 }
 
+function writeGrowthEvent(request, env, event) {
+  const output = {
+    type: "blueballs_growth_event",
+    name: event.name,
+    path: cleanString(event.path, 160) || new URL(request.url).pathname,
+    session_id: cleanString(event.session_id, 80) || null,
+    attribution: cleanProperties(event.attribution),
+    properties: cleanProperties(event.properties),
+    country: cleanString(request.cf?.country, 8) || null,
+    referrer_host: referrerHost(request),
+    source_commit: cleanString(env.BLUEBALLS_GIT_SHA, 64) || "development",
+  };
+  console.log(JSON.stringify(output));
+  return output;
+}
+
+export function logServerGrowthEvent(request, env, name, properties = {}) {
+  if (!SERVER_EVENTS.has(name)) return false;
+  writeGrowthEvent(request, env, {
+    name,
+    path: new URL(request.url).pathname,
+    session_id: null,
+    attribution: {},
+    properties,
+  });
+  return true;
+}
+
 export async function handleGrowthEvent(request, env) {
   if (request.method !== "POST") {
     return new Response(null, {
@@ -66,7 +100,10 @@ export async function handleGrowthEvent(request, env) {
   }
 
   if (!sameOrigin(request)) {
-    return Response.json({ error: "Cross-origin events are not accepted." }, { status: 403 });
+    return Response.json(
+      { error: "Cross-origin events are not accepted." },
+      { status: 403 },
+    );
   }
 
   const declared = Number(request.headers.get("content-length") || 0);
@@ -87,28 +124,17 @@ export async function handleGrowthEvent(request, env) {
   }
 
   const name = cleanString(body?.name, 64);
-  if (!ALLOWED_EVENTS.has(name)) {
+  if (!CLIENT_EVENTS.has(name)) {
     return Response.json({ error: "Unknown event." }, { status: 400 });
   }
 
-  const attribution = cleanProperties(body?.attribution);
-  const event = {
-    type: "blueballs_growth_event",
+  writeGrowthEvent(request, env, {
     name,
-    path: cleanString(body?.path, 160) || "/",
-    session_id: cleanString(body?.session_id, 80) || null,
-    attribution,
-    properties: cleanProperties(body?.properties),
-    country: cleanString(request.cf?.country, 8) || null,
-    referrer_host: referrerHost(request),
-    source_commit: cleanString(env.BLUEBALLS_GIT_SHA, 64) || "development",
-  };
-
-  // The Site Worker already has Cloudflare observability enabled. Structured
-  // JSON makes these events queryable immediately without introducing user PII,
-  // cookies or a third-party analytics dependency. A future Analytics Engine or
-  // warehouse sink can consume the same stable event schema.
-  console.log(JSON.stringify(event));
+    path: body?.path,
+    session_id: body?.session_id,
+    attribution: body?.attribution,
+    properties: body?.properties,
+  });
 
   return new Response(null, {
     status: 204,
@@ -116,4 +142,4 @@ export async function handleGrowthEvent(request, env) {
   });
 }
 
-export { ALLOWED_EVENTS };
+export { CLIENT_EVENTS, SERVER_EVENTS };

--- a/workers/site/growth-events.js
+++ b/workers/site/growth-events.js
@@ -10,6 +10,7 @@ const ALLOWED_EVENTS = new Set([
   "provider_partnership_start",
   "builder_start",
   "commercial_cta",
+  "commercial_contact_view",
 ]);
 
 const MAX_BODY_BYTES = 4096;

--- a/workers/site/growth-events.js
+++ b/workers/site/growth-events.js
@@ -1,0 +1,104 @@
+const ALLOWED_EVENTS = new Set([
+  "provider_directory_view",
+  "provider_filter",
+  "provider_search",
+  "provider_shortlist",
+  "provider_unshortlist",
+  "provider_compare",
+  "provider_outbound",
+  "provider_claim_start",
+  "provider_partnership_start",
+  "builder_start",
+  "commercial_cta",
+]);
+
+const MAX_BODY_BYTES = 4096;
+const MAX_PROPERTIES = 12;
+const MAX_STRING = 160;
+
+function cleanString(value, max = MAX_STRING) {
+  if (typeof value !== "string") return "";
+  return value.slice(0, max).replace(/[\u0000-\u001f\u007f]/g, "");
+}
+
+function cleanProperties(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const entries = Object.entries(value).slice(0, MAX_PROPERTIES);
+  return Object.fromEntries(
+    entries.flatMap(([key, item]) => {
+      const safeKey = cleanString(key, 48);
+      if (!safeKey) return [];
+      if (typeof item === "string") return [[safeKey, cleanString(item)]];
+      if (typeof item === "number" && Number.isFinite(item)) return [[safeKey, item]];
+      if (typeof item === "boolean" || item === null) return [[safeKey, item]];
+      return [];
+    }),
+  );
+}
+
+function referrerHost(request) {
+  const referrer = request.headers.get("referer");
+  if (!referrer) return null;
+  try {
+    return new URL(referrer).hostname.slice(0, 120);
+  } catch {
+    return null;
+  }
+}
+
+export async function handleGrowthEvent(request, env) {
+  if (request.method !== "POST") {
+    return new Response(null, {
+      status: 405,
+      headers: { allow: "POST", "cache-control": "no-store" },
+    });
+  }
+
+  const declared = Number(request.headers.get("content-length") || 0);
+  if (declared > MAX_BODY_BYTES) {
+    return Response.json({ error: "Event payload too large." }, { status: 413 });
+  }
+
+  const raw = await request.text();
+  if (raw.length > MAX_BODY_BYTES) {
+    return Response.json({ error: "Event payload too large." }, { status: 413 });
+  }
+
+  let body;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return Response.json({ error: "Invalid event payload." }, { status: 400 });
+  }
+
+  const name = cleanString(body?.name, 64);
+  if (!ALLOWED_EVENTS.has(name)) {
+    return Response.json({ error: "Unknown event." }, { status: 400 });
+  }
+
+  const attribution = cleanProperties(body?.attribution);
+  const event = {
+    type: "blueballs_growth_event",
+    name,
+    path: cleanString(body?.path, 160) || "/",
+    session_id: cleanString(body?.session_id, 80) || null,
+    attribution,
+    properties: cleanProperties(body?.properties),
+    country: cleanString(request.cf?.country, 8) || null,
+    referrer_host: referrerHost(request),
+    source_commit: cleanString(env.BLUEBALLS_GIT_SHA, 64) || "development",
+  };
+
+  // The Site Worker already has Cloudflare observability enabled. Structured
+  // JSON makes these events queryable immediately without introducing user PII,
+  // cookies or a third-party analytics dependency. A future Analytics Engine or
+  // warehouse sink can consume the same stable event schema.
+  console.log(JSON.stringify(event));
+
+  return new Response(null, {
+    status: 204,
+    headers: { "cache-control": "no-store" },
+  });
+}
+
+export { ALLOWED_EVENTS };

--- a/workers/site/growth-events.test.js
+++ b/workers/site/growth-events.test.js
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { handleGrowthEvent } from "./growth-events.js";
+import {
+  handleGrowthEvent,
+  logServerGrowthEvent,
+} from "./growth-events.js";
 
 const env = { BLUEBALLS_GIT_SHA: "test-sha" };
 
@@ -42,6 +45,30 @@ test("growth event intake accepts an allowlisted event and logs bounded structur
     assert.equal(event.properties.ignored_nested, undefined);
     assert.equal(event.referrer_host, "blueballs.tech");
     assert.equal(event.source_commit, "test-sha");
+  } finally {
+    console.log = original;
+  }
+});
+
+test("server-confirmed Builder signals use canonical low-cardinality paths", () => {
+  const lines = [];
+  const original = console.log;
+  console.log = (line) => lines.push(line);
+  try {
+    const accepted = logServerGrowthEvent(
+      new Request(
+        "https://blueballs.tech/v2/builder/projects/project-secret/provision",
+      ),
+      env,
+      "builder_sandbox_provisioned",
+      { response_status: 200 },
+    );
+    assert.equal(accepted, true);
+    const event = JSON.parse(lines[0]);
+    assert.equal(event.name, "builder_sandbox_provisioned");
+    assert.equal(event.path, "/v2/builder/projects/:id/provision");
+    assert.equal(event.properties.response_status, 200);
+    assert.doesNotMatch(event.path, /project-secret/);
   } finally {
     console.log = original;
   }

--- a/workers/site/growth-events.test.js
+++ b/workers/site/growth-events.test.js
@@ -14,6 +14,7 @@ test("growth event intake accepts an allowlisted event and logs bounded structur
         method: "POST",
         headers: {
           "content-type": "application/json",
+          origin: "https://blueballs.tech",
           referer: "https://blueballs.tech/ecosystem?utm_source=test",
         },
         body: JSON.stringify({
@@ -56,6 +57,21 @@ test("growth event intake rejects unknown event names", async () => {
     env,
   );
   assert.equal(response.status, 400);
+});
+
+test("growth event intake rejects cross-origin browser submissions", async () => {
+  const response = await handleGrowthEvent(
+    new Request("https://blueballs.tech/api/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "https://example.com",
+      },
+      body: JSON.stringify({ name: "provider_directory_view" }),
+    }),
+    env,
+  );
+  assert.equal(response.status, 403);
 });
 
 test("growth event intake rejects non-POST requests", async () => {

--- a/workers/site/growth-events.test.js
+++ b/workers/site/growth-events.test.js
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { handleGrowthEvent } from "./growth-events.js";
+
+const env = { BLUEBALLS_GIT_SHA: "test-sha" };
+
+test("growth event intake accepts an allowlisted event and logs bounded structured data", async () => {
+  const lines = [];
+  const original = console.log;
+  console.log = (line) => lines.push(line);
+  try {
+    const response = await handleGrowthEvent(
+      new Request("https://blueballs.tech/api/events", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          referer: "https://blueballs.tech/ecosystem?utm_source=test",
+        },
+        body: JSON.stringify({
+          name: "provider_shortlist",
+          path: "/ecosystem",
+          session_id: "session-test",
+          attribution: { source: "launch", medium: "social" },
+          properties: {
+            provider: "example-provider",
+            shortlist_size: 2,
+            ignored_nested: { secret: "not-logged" },
+          },
+        }),
+      }),
+      env,
+    );
+
+    assert.equal(response.status, 204);
+    assert.equal(lines.length, 1);
+    const event = JSON.parse(lines[0]);
+    assert.equal(event.type, "blueballs_growth_event");
+    assert.equal(event.name, "provider_shortlist");
+    assert.equal(event.properties.provider, "example-provider");
+    assert.equal(event.properties.shortlist_size, 2);
+    assert.equal(event.properties.ignored_nested, undefined);
+    assert.equal(event.referrer_host, "blueballs.tech");
+    assert.equal(event.source_commit, "test-sha");
+  } finally {
+    console.log = original;
+  }
+});
+
+test("growth event intake rejects unknown event names", async () => {
+  const response = await handleGrowthEvent(
+    new Request("https://blueballs.tech/api/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "arbitrary_event" }),
+    }),
+    env,
+  );
+  assert.equal(response.status, 400);
+});
+
+test("growth event intake rejects non-POST requests", async () => {
+  const response = await handleGrowthEvent(
+    new Request("https://blueballs.tech/api/events"),
+    env,
+  );
+  assert.equal(response.status, 405);
+  assert.equal(response.headers.get("allow"), "POST");
+});
+
+test("growth event intake rejects oversized payloads", async () => {
+  const response = await handleGrowthEvent(
+    new Request("https://blueballs.tech/api/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "provider_search",
+        properties: { value: "x".repeat(5000) },
+      }),
+    }),
+    env,
+  );
+  assert.equal(response.status, 413);
+});

--- a/workers/site/index.js
+++ b/workers/site/index.js
@@ -7,6 +7,7 @@ import {
   robotsText,
   sitemapXml,
 } from "./crawler-pages.js";
+import { handleGrowthEvent } from "./growth-events.js";
 import { runtimeForPath } from "../../spec/runtime-ownership.mjs";
 import { getAgentByName } from "agents";
 export { NeobankBuilder } from "./neobank-builder.js";
@@ -136,6 +137,10 @@ async function handleRequest(request, env) {
 
   if (url.pathname === "/bulletin") {
     return Response.redirect(new URL("/developers", url).toString(), 301);
+  }
+
+  if (url.pathname === "/api/events") {
+    return handleGrowthEvent(request, env);
   }
 
   // Runtime ownership is defined once in spec/runtime-ownership.mjs. The edge

--- a/workers/site/index.js
+++ b/workers/site/index.js
@@ -7,7 +7,10 @@ import {
   robotsText,
   sitemapXml,
 } from "./crawler-pages.js";
-import { handleGrowthEvent } from "./growth-events.js";
+import {
+  handleGrowthEvent,
+  logServerGrowthEvent,
+} from "./growth-events.js";
 import { runtimeForPath } from "../../spec/runtime-ownership.mjs";
 import { getAgentByName } from "agents";
 export { NeobankBuilder } from "./neobank-builder.js";
@@ -49,6 +52,16 @@ function internalRequest(request, headers) {
   next.delete("origin");
   for (const [name, value] of Object.entries(headers)) next.set(name, value);
   return new Request(request, { headers: next });
+}
+
+function builderGrowthEvent(request, pathname) {
+  if (request.method !== "POST") return null;
+  if (pathname === "/v2/builder/projects") return "builder_blueprint_created";
+  if (/^\/v2\/builder\/projects\/[^/]+\/provision$/.test(pathname))
+    return "builder_sandbox_provisioned";
+  if (/^\/v2\/builder\/projects\/[^/]+\/test-payments$/.test(pathname))
+    return "builder_test_payment";
+  return null;
 }
 
 export default {
@@ -237,7 +250,14 @@ async function handleRequest(request, env) {
   }
 
   if (url.pathname === "/v2" || url.pathname.startsWith("/v2/")) {
-    return env.API.fetch(internalRequest(request, {}));
+    const response = await env.API.fetch(internalRequest(request, {}));
+    const growthEvent = builderGrowthEvent(request, url.pathname);
+    if (response.ok && growthEvent) {
+      logServerGrowthEvent(request, env, growthEvent, {
+        response_status: response.status,
+      });
+    }
+    return response;
   }
 
   if (url.pathname === "/api/health") {


### PR DESCRIPTION
## Outcome

Turn the existing Builder + provider directory into the first measurable Blueballs growth and monetization loop.

This is the first implementation tranche of the provider-funded model: builders stay free, while Blueballs begins measuring the infrastructure decisions that can eventually power provider distribution, qualified demand and implementation revenue.

## What ships

### Builder funnel
- records entry into the Sandbox from internal product routes;
- records **server-confirmed** successful Blueprint creation, sandbox provisioning and test payments at the public edge;
- keeps server activation events low-cardinality and does not log project IDs;
- separates contact-page arrival from explicit commercial CTA intent.

### Provider decision journey
- turns the provider directory into a decision surface rather than a static catalogue;
- lets builders shortlist up to three providers;
- persists the shortlist locally;
- adds side-by-side comparison across access, sandbox, technical status, regions and capabilities;
- tracks filter, search, shortlist, compare and official provider outbound actions;
- adds a direct implementation CTA from a provider comparison.

### Provider acquisition
- adds a dedicated **Claim or update a provider profile** workflow;
- keeps a free profile claim separate from commercial partnership;
- upgrades the provider partnership intake to cover adapters, compatibility, reference implementations / Blueprints, launches, research, qualified-demand pilots and design / implementation work;
- explicitly states that commercial participation does not buy organic ranking or technical verification.

### Measurement boundary
- adds a small allow-listed growth event schema at `/api/events`;
- uses per-session IDs and first-touch UTM attribution only;
- records coarse Cloudflare country + referrer host, not raw IPs or PII;
- bounds body size, keys and property values;
- drops nested/unapproved data;
- rejects cross-origin browser submissions;
- uses existing Cloudflare structured logs rather than adding a third-party tracker or cookie layer.

## Business logic

The initial measurable funnel becomes:

`visit → Sandbox → Blueprint created → sandbox provisioned → test payment`

and

`provider directory → search/filter → shortlist → compare → provider outbound / profile claim / commercial contact`

These are the first observable precursors to Blueballs' proposed Qualified Infrastructure Decision (QID) model.

## Trust rule

Paid ≠ recommended.

A provider can claim factual profile data for free. Commercial relationships are a separate lane. Organic technical status and future verification remain evidence-driven.

## Verification performed

- branch is based directly on the current `main`;
- growth-event handler syntax and behavior were exercised independently under Node, including accepted events, cross-origin rejection, unknown-event rejection, oversized-event rejection and canonical server activation paths;
- repository tests were extended so `test:workers` includes growth-event coverage and edge ownership assertions;
- no banking, ledger, FX, settlement or provider-finality contract was changed;
- no GitHub Actions or new third-party runtime dependency was introduced.

Full `pnpm verify:release` was not claimed from this environment; the repository-local release gate remains the authority for a deployable release.