### PR TITLE
Package the Blueballs v0.2 launch story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Tagged releases follow semantic versioning.
 
 ## [Unreleased]
 
-This cycle takes Blueballs far beyond the initial public release: a harder banking core, a real provider orchestration boundary, institution-owned FX production composition, stronger settlement contracts and reproducible release proof.
+This cycle takes Blueballs far beyond the initial public release: a harder banking core, a real provider orchestration boundary, institution-owned FX production composition, stronger settlement contracts, reusable financial-product Blueprints and public, source-linked release proof.
 
 ### Banking core
 
@@ -40,12 +40,22 @@ This cycle takes Blueballs far beyond the initial public release: a harder banki
 - **Vault and settlement invariants** cover solvency, surplus-only rescue, partial-fill accounting, cancellation and bounded withdrawal-delay incident controls.
 - **Foundry assurance** combines unit, fuzz and invariant testing for the token settlement kernel.
 
+### Product design, provider decisions and distribution
+
+- **Deterministic infrastructure matching** turns a Builder Blueprint into an explainable provider shortlist based on capability fit, declared market coverage and explicit rail evidence. Commercial relationships do not affect ranking.
+- **Persistent provider decisions** let builders shortlist and compare infrastructure, open official technical documentation, claim provider profiles and start a separate commercial provider route without turning the directory into pay-to-play.
+- **Shareable Blueprints** serialize only public-safe product architecture into a fragment link, so another builder can inspect and fork markets, currencies, capabilities and rails without exposing sandbox customers, balances, transactions, credentials or tenant state.
+- **The Blueprint Library** adds eight reusable product architectures across creator banking, freelancer finance, stablecoin treasury, remittance, cards, merchant settlement, community wallets and institution-owned FX.
+- **Implementation briefs** convert a Blueprint and user-selected provider shortlist into concrete workstreams and a copyable public-safe handoff for a technical team or Blueballs implementation engagement.
+- **Builder activation and demand signals** distinguish page intent from completed Blueprints, provisioned sandboxes, test payments, provider decisions, Blueprint distribution and implementation-intake starts using bounded first-party events.
+
 ### Release proof
 
 - **Repository-local release authority** now runs from the exact candidate checkout rather than depending on a hosted CI vendor.
 - **`pnpm verify:release`** combines build/types, banking and FX suites, Workers, OpenAPI/SDK contracts, Foundry, secrets/dependencies, SBOM, restart/chaos, disposable load proof and container scanning.
 - **Exact-checkout evidence** records the commit, Git tree, toolchain, lockfile digest, API operation coverage and release-gate results.
 - **Deployment parity guards** verify that the public site, banking API and FX runtime converge on the same source commit after promotion.
+- **Public Proof** exposes live site/banking/FX source parity from `/api/health` alongside source-linked verification, release and deployment gates. The public claims are checked against the repository scripts as part of publication truth.
 
 ## [0.1.0] - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
   <a href="https://blueballs.tech/fx">FX Market</a> ·
   <a href="https://blueballs.tech/cards">Cards</a> ·
   <a href="https://blueballs.tech/ecosystem">Providers</a> ·
+  <a href="https://blueballs.tech/blueprint">Blueprints</a> ·
+  <a href="https://blueballs.tech/proof">Proof</a> ·
   <a href="https://blueballs.tech/sandbox">Build in the Sandbox</a> ·
   <a href="https://blueballs.tech/developers">API</a> ·
   <a href="https://blueballs.tech/contact">Build with Blueballs</a>
@@ -48,10 +50,10 @@ Clone it. Inspect it. Fork it. Connect the providers you want. Shape the product
 | **FX** | Policy-aware pricing, private and institutional liquidity, route construction, reservations, treasury/principal capacity, fiat evidence and execution adapters |
 | **Settlement** | Optional Blueballs AtomicRouter contracts for signed taker intent, maker liquidity, cancellation, segregated vault accounting and atomic token settlement |
 | **Money primitives** | A reference monetary engine for reserve-backed instruments, settlement receipts and coverage accounting |
-| **Product layer** | Interactive banking, cards, provider and FX experiences plus a Sandbox Builder for designing and exercising financial products |
+| **Product layer** | Interactive banking and FX experiences, Blueprint Library, provider decision tools, Cards market explorer, Sandbox Builder and generated implementation briefs |
 | **Runtime** | Node.js/SQLite and Cloudflare Workers/Durable Objects using shared financial contracts |
 | **Developer platform** | Generated OpenAPI, SDK contracts, provider conformance boundaries and executable examples |
-| **Release proof** | Exact-checkout verification covering lifecycle tests, restart/eviction, migrations, recovery, load/chaos, dependency inventory and container scanning |
+| **Release proof** | Public Proof plus exact-checkout verification covering lifecycle tests, restart/eviction, migrations, recovery, load/chaos, dependency inventory and container scanning |
 
 ## Not another neobank template
 
@@ -108,6 +110,20 @@ Explore the interactive market at **[blueballs.tech/fx](https://blueballs.tech/f
 The **Blueballs Sandbox Builder** turns product strategy into something executable.
 
 Start with a brief, define the audience and markets, choose currencies, capabilities and rails, shape the product, then exercise the same banking contracts that power the rest of the repository.
+
+A Blueprint can now move through the full decision and distribution loop:
+
+1. define markets, currencies, capabilities and rails;
+2. generate explainable provider matches from capability fit, declared market coverage and explicit rail evidence;
+3. shortlist infrastructure and inspect official technical documentation;
+4. provision an isolated sandbox and exercise protected-ledger journeys;
+5. share a public-safe Blueprint link and let another builder inspect or fork the architecture;
+6. generate a concrete implementation brief from the Blueprint and user-selected shortlist;
+7. take that brief into your own technical team or the Blueballs implementation route.
+
+Provider matching is deliberately non-commercial: sponsorship or commercial relationships do not affect ranking.
+
+Start from scratch or fork one of eight reusable architectures in the **[Blueprint Library](https://blueballs.tech/blueprint)**.
 
 The hosted Builder can help turn an idea into a focused product blueprint without giving an AI model arbitrary authority over customer money.
 
@@ -238,6 +254,8 @@ The full profile exercises build/types, lint/format, the banking lifecycle catal
 
 Machine-readable evidence is tied to the exact commit, Git tree and lockfile.
 
+**[Blueballs Proof](https://blueballs.tech/proof)** exposes live site, banking and FX source-SHA parity from `/api/health` and links directly to the verification, release and deployment gates in source. The public proof claims are themselves checked against those repository scripts by the publication-truth gate.
+
 Focused commands:
 
 ```bash
@@ -261,7 +279,7 @@ The project is deliberately provider-neutral and jurisdiction-flexible so seriou
 
 **Blueballs is free to use. If you want the project involved in product design, integration, deployment or operating architecture, [build with Blueballs](https://blueballs.tech/contact).**
 
-**[Explore Blueballs](https://blueballs.tech)** · **[Build in the Sandbox](https://blueballs.tech/sandbox)** · **[Read the API](https://blueballs.tech/developers)** · **[Build with Blueballs](https://blueballs.tech/contact)**
+**[Explore Blueballs](https://blueballs.tech)** · **[Blueprint Library](https://blueballs.tech/blueprint)** · **[Build in the Sandbox](https://blueballs.tech/sandbox)** · **[Proof](https://blueballs.tech/proof)** · **[Read the API](https://blueballs.tech/developers)** · **[Build with Blueballs](https://blueballs.tech/contact)**
 
 ## Documentation
 
@@ -271,6 +289,7 @@ The project is deliberately provider-neutral and jurisdiction-flexible so seriou
 | [ARCHITECTURE.md](ARCHITECTURE.md) | System architecture, ownership and extension points |
 | [PRODUCTION-HARDENING.md](PRODUCTION-HARDENING.md) | Executable engineering assurance |
 | [SANDBOX.md](SANDBOX.md) | Sandbox Builder |
+| [docs/releases/v0.2.0.md](docs/releases/v0.2.0.md) | Publish-ready v0.2 launch notes |
 | [apps/api/README.md](apps/api/README.md) | Banking runtime |
 | [apps/fx-node/README.md](apps/fx-node/README.md) | FX runtime and production composition |
 | [packages/fx-sdk/README.md](packages/fx-sdk/README.md) | JavaScript FX SDK |

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,0 +1,160 @@
+# Blueballs v0.2.0 — Own the Financial Stack
+
+Blueballs v0.2 turns the first public release into a much more complete open financial operating system: a harder banking core, durable provider orchestration, institution-owned FX, stronger settlement contracts, reusable product Blueprints and source-linked public proof.
+
+The product loop is now simple:
+
+**Design it → choose the infrastructure → share it → fork it → implement it.**
+
+Blueballs remains MIT licensed and self-hostable. The point is not to hide regulated infrastructure behind another black box. The point is to let a builder or institution own the product contract, ledger, provider composition, policy, FX economics and deployment model around it.
+
+## 1. From blank page to financial product
+
+The Sandbox Builder now goes beyond provisioning test state.
+
+A product brief becomes a structured Blueprint with markets, currencies, capabilities and rails. From there Blueballs can:
+
+- generate explainable provider matches from the public provider graph;
+- persist a three-provider shortlist for comparison;
+- open official provider documentation;
+- share a public-safe Blueprint link;
+- fork that architecture into another Builder session;
+- turn the Blueprint and shortlist into a concrete implementation brief.
+
+Provider ranking is deterministic and provider-neutral. Capability fit, declared market coverage and explicit rail evidence drive the order. Commercial relationships do not.
+
+## 2. A Blueprint Library for financial products
+
+Blueballs now ships a public Blueprint Library with eight reusable architectures:
+
+1. Creator Bank Singapore
+2. Freelancer Current Account
+3. Stablecoin Treasury
+4. SEA Remittance Network
+5. Stablecoin Card Programme
+6. Merchant Settlement Network
+7. Community Wallet
+8. Institution-Owned FX Desk
+
+Each Blueprint can be inspected, matched to infrastructure, converted into an implementation scope and forked directly into Builder.
+
+The share format is deliberately small and public-safe. It contains only product architecture: name, markets, currencies, capabilities, rails and an optional accent. Sandbox IDs, credentials, customers, balances, transactions, free-text audience descriptions and tenant state stay out of the shared link.
+
+## 3. A harder banking core
+
+The banking runtime now treats financial commands as one authoritative local unit: resource state, exact ledger postings, durable events/outboxes, idempotency and audit evidence move together.
+
+Highlights include:
+
+- 181 banking operations classified across permissions, runtime modes and production ownership;
+- exact decimal accounting through integer minor-unit arithmetic;
+- scoped machine credentials;
+- signed named-human attribution from external IAM/session gateways;
+- production bootstrap and credential recovery;
+- restart, migration and Durable Object eviction coverage;
+- operational health, backlog and reconciliation signals.
+
+## 4. Provider orchestration that can survive the real world
+
+Provider-backed workflows now share one capability-driven gateway model across payments, cards, receiving details, identity and custody.
+
+The runtime includes:
+
+- stable external idempotency;
+- durable outboxes, leases, retry history and reconciliation;
+- capability-specific financial finality contracts;
+- AES-256-GCM provider payload envelopes with key IDs;
+- signed provider-originated settlement evidence;
+- replay protection by event ID and provider settlement reference;
+- durable signed webhook delivery with exact HTTPS host allowlisting.
+
+Blueballs still does not pretend a directory listing is an integration or partnership. Technical status and relationship status remain explicit.
+
+## 5. Build and operate your own FX market
+
+FX is now one of the clearest Blueballs differentiators.
+
+The canonical FX stack lets an institution compose:
+
+- private customer order flow;
+- issuer inventory;
+- professional market makers or liquidity providers;
+- another institution;
+- treasury or principal balance sheet capacity;
+- external venues.
+
+Policy, exact pricing, reservations, routing, execution and mixed-finality settlement remain under one institution-owned control plane.
+
+Production composition is adapter-driven through `FX_NODE_PRODUCTION_ADAPTER`. The production runtime validates the complete market, quote, fiat and execution boundary before it serves traffic.
+
+The public FX product is an interactive market and architecture lab rather than a static rate calculator.
+
+## 6. Stronger atomic settlement
+
+The Solidity settlement kernel now has broader assurance around:
+
+- institution-authorized taker intent;
+- maker signatures and smart-wallet signatures;
+- nonce replay protection;
+- route-level max-input/min-output controls;
+- partial-fill accounting;
+- cancellation;
+- vault solvency;
+- surplus-only rescue;
+- bounded withdrawal-delay incident controls.
+
+Foundry format, build, fuzz and invariant tests are part of the repository verification path.
+
+## 7. Proof is a product surface
+
+Blueballs now publishes `/proof` as a first-class technical-sales and trust surface.
+
+The live page reads the existing `/api/health` contract and shows:
+
+- the site source commit;
+- the banking source commit;
+- the FX source commit;
+- component HTTP status;
+- whether all three are converged on the same exact source SHA.
+
+It also links directly to the source for the standard verification gate, full release profile and deployment-promotion checks.
+
+The public Proof claims are themselves tied back to the repository. If the verification, release or deployment scripts drift away from the published story, repository publication checks fail until the Proof copy is corrected.
+
+## 8. Release proof stays with the code
+
+The standard gate remains:
+
+```bash
+pnpm verify
+```
+
+The clean-checkout release gate is:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm verify:release
+```
+
+The full release profile combines build/types, banking and FX suites, Workers, OpenAPI/SDK contracts, Foundry, secret/dependency checks, CycloneDX inventory, restart/chaos, disposable banking + FX load proof and reference-container vulnerability scanning.
+
+Release evidence is tied to the exact commit, Git tree and lockfile.
+
+Cloudflare promotion additionally requires a clean checkout where local `HEAD` equals `origin/main`, injects the exact source SHA as `BLUEBALLS_GIT_SHA`, and checks live site/banking/FX convergence after deployment.
+
+## Try the system
+
+- **Website:** https://blueballs.tech
+- **Blueprint Library:** https://blueballs.tech/blueprint
+- **Sandbox Builder:** https://blueballs.tech/sandbox
+- **Provider Directory:** https://blueballs.tech/ecosystem
+- **Stablecoin FX:** https://blueballs.tech/fx
+- **Cards:** https://blueballs.tech/cards
+- **Technical Proof:** https://blueballs.tech/proof
+- **API:** https://blueballs.tech/developers
+- **Build with Blueballs:** https://blueballs.tech/contact
+- **Source:** https://github.com/Josh-Gi3r/blueballs
+
+## Publication gate
+
+This file is the publish-ready v0.2.0 release-note source. A v0.2.0 tag or GitHub Release should be created only after the exact candidate checkout satisfies `RELEASE.md`, including `pnpm verify:release`, and the tag is verified to point to that exact commit.


### PR DESCRIPTION
## Outcome

Package the current post-v0.1 product into a coherent, publish-ready v0.2 story without pretending the release/tag exists before the exact candidate passes the repository release gate.

The release theme is **Blueballs v0.2.0 — Own the Financial Stack**.

## What changes

### README
The public repository story now reflects the product that actually exists after the recent build cycle:
- Blueprint Library;
- deterministic provider decisions and shortlist;
- public-safe share/fork Blueprints;
- generated implementation briefs;
- public Proof with live site/banking/FX source parity;
- the existing 181-operation banking core, provider orchestration, institution-owned FX and settlement kernel remain the architecture anchor.

### Changelog
`[Unreleased]` now captures the user-facing v0.2 capability expansion across:
- banking core;
- provider orchestration;
- institution-owned FX;
- atomic settlement;
- product design, provider decisions and distribution;
- repository-local release proof and public Proof.

This deliberately remains `[Unreleased]`; it does not add a v0.2 release date or claim publication.

### Publish-ready release notes
Adds `docs/releases/v0.2.0.md` with the launch narrative:

**Design it → choose the infrastructure → share it → fork it → implement it.**

The release note covers the Blueprint Library, Builder/provider/implementation loop, banking/provider/FX/settlement advances, public Proof and the exact-checkout release model.

## What this PR does NOT do

- does not change `package.json` version;
- does not create a `v0.2.0` tag;
- does not create a GitHub Release object;
- does not claim `pnpm verify:release` passed from this environment;
- does not deploy the site/runtime.

Those publication actions remain governed by `RELEASE.md`: the exact candidate must pass `pnpm verify:release`, the tag must point to that exact commit, and the GitHub Release should then use `docs/releases/v0.2.0.md` as its release copy.

## Scope safety

This PR changes documentation/story packaging only. No banking, ledger, FX, settlement, provider, Worker or product runtime code changes.