### PR TITLE
Make client navigation executable and expose v0.2 surfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "preview:upload": "pnpm build && wrangler versions upload -c wrangler.jsonc",
     "test:api": "pnpm --dir apps/api test:ci",
     "test:fx": "node scripts/test-fx.mjs",
-    "test:workers": "pnpm --dir packages/sqlite-compat test:ci && node --test workers/site/edge-routing.test.js workers/site/growth-events.test.js && vitest run --config vitest.config.mts && vitest run --config vitest.api.config.mts && vitest run --config vitest.fx.config.mts",
+    "test:workers": "pnpm --dir packages/sqlite-compat test:ci && node --test workers/site/edge-routing.test.js workers/site/growth-events.test.js workers/site/client-navigation.test.js && vitest run --config vitest.config.mts && vitest run --config vitest.api.config.mts && vitest run --config vitest.fx.config.mts",
     "verify": "node scripts/release-proof.mjs",
     "verify:release": "node scripts/release-proof.mjs --require-clean --full",
     "verify:raw": "node scripts/verify.mjs",

--- a/scripts/check-site-routes.mjs
+++ b/scripts/check-site-routes.mjs
@@ -17,6 +17,10 @@ const preview = readFileSync(
   "utf8",
 );
 const router = readFileSync(new URL("../src/router.ts", import.meta.url), "utf8");
+const routerCore = readFileSync(
+  new URL("../src/router-core.ts", import.meta.url),
+  "utf8",
+);
 const brand = readFileSync(new URL("../src/Brand.tsx", import.meta.url), "utf8");
 const siteRoot = readFileSync(
   new URL("../src/SiteRoot.tsx", import.meta.url),
@@ -70,12 +74,28 @@ assert.match(
   "the site must set a permissions policy",
 );
 
-// Cross-shell navigation is one location contract: both SiteRoot and page-level
-// route consumers observe the same History API transition through usePath().
+// Cross-shell navigation is one location contract: usePath delegates all writes
+// to the executable router core, which pushes a real URL, broadcasts the change
+// and resets scroll. Its behavior is covered by client-navigation.test.js.
 assert.match(
   router,
-  /history\.pushState\([\s\S]*dispatchEvent\(new PopStateEvent\("popstate"\)\)/,
-  "client navigation must broadcast popstate after pushState",
+  /navigatePath\(p,[\s\S]*pathname: window\.location\.pathname/,
+  "usePath must delegate navigation to the shared router core",
+);
+assert.match(
+  routerCore,
+  /runtime\.pushState\(destination\);[\s\S]*runtime\.broadcastLocationChange\(\);[\s\S]*runtime\.scrollToTop\(\);/,
+  "client navigation must push the URL, broadcast the location change and reset scroll",
+);
+assert.match(
+  routerCore,
+  /destination === "\/sandbox"[\s\S]*growthEvent = "builder_start"/,
+  "Sandbox navigation must retain Builder attribution",
+);
+assert.match(
+  routerCore,
+  /destination === "\/contact"[\s\S]*growthEvent = "commercial_contact_view"/,
+  "commercial navigation must retain source attribution",
 );
 assert.match(
   siteRoot,
@@ -203,5 +223,5 @@ assert.match(preview, /wrangler\.api\.jsonc/);
 assert.match(preview, /wrangler\.fx\.jsonc/);
 assert.match(preview, /LOCAL_DEV:true/);
 console.log(
-  "site route contract: shared navigation is synchronized, Cards has one canonical market-intelligence surface, Blueprints and Proof are public/crawlable product surfaces, and /contact is a first-class build route",
+  "site route contract: executable client navigation stays synchronized, Cards has one canonical market-intelligence surface, Blueprints and Proof are public/crawlable product surfaces, and /contact is a first-class build route",
 );

--- a/scripts/check-site-routes.mjs
+++ b/scripts/check-site-routes.mjs
@@ -142,6 +142,16 @@ assert.match(
   /href="\/home"/,
   "interior brand links must return to the canonical site home",
 );
+assert.match(
+  brand,
+  /href="\/blueprint"/,
+  "the full shared brand lockup must expose the Blueprint Library",
+);
+assert.match(
+  brand,
+  /href="\/proof"/,
+  "the full shared brand lockup must expose public Proof",
+);
 
 // Keep one public Cards implementation and one loaded Cards stylesheet.
 assert.match(
@@ -223,5 +233,5 @@ assert.match(preview, /wrangler\.api\.jsonc/);
 assert.match(preview, /wrangler\.fx\.jsonc/);
 assert.match(preview, /LOCAL_DEV:true/);
 console.log(
-  "site route contract: executable client navigation stays synchronized, Cards has one canonical market-intelligence surface, Blueprints and Proof are public/crawlable product surfaces, and /contact is a first-class build route",
+  "site route contract: executable client navigation stays synchronized, Blueprints and Proof are discoverable from the shared brand, Cards has one canonical market-intelligence surface, and /contact is a first-class build route",
 );

--- a/src/Brand.tsx
+++ b/src/Brand.tsx
@@ -54,7 +54,7 @@ export function BrandLockup({
     return <span className="bb-brand-lockup">{contents}</span>;
   }
 
-  return (
+  const home = (
     <a
       className="bb-brand-lockup"
       href="/home"
@@ -63,5 +63,57 @@ export function BrandLockup({
     >
       {contents}
     </a>
+  );
+
+  if (compact) return home;
+
+  return (
+    <span
+      className="bb-brand-cluster"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 11,
+        flexWrap: "wrap",
+      }}
+    >
+      {home}
+      <span
+        aria-label="Blueballs product shortcuts"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          paddingLeft: 11,
+          borderLeft: `1px solid ${inverse ? "#34416A" : "#D7DBE4"}`,
+          fontFamily: "'IBM Plex Mono', monospace",
+          fontSize: 8.5,
+          letterSpacing: "0.07em",
+          whiteSpace: "nowrap",
+        }}
+      >
+        <a
+          href="/blueprint"
+          style={{
+            color: inverse ? "#C5CAD7" : "#5B6376",
+            textDecoration: "none",
+          }}
+        >
+          BLUEPRINTS
+        </a>
+        <span aria-hidden="true" style={{ color: inverse ? "#66708A" : "#A7AEBB" }}>
+          ·
+        </span>
+        <a
+          href="/proof"
+          style={{
+            color: inverse ? "#C5CAD7" : "#5B6376",
+            textDecoration: "none",
+          }}
+        >
+          PROOF
+        </a>
+      </span>
+    </span>
   );
 }

--- a/src/Brand.tsx
+++ b/src/Brand.tsx
@@ -101,7 +101,10 @@ export function BrandLockup({
         >
           BLUEPRINTS
         </a>
-        <span aria-hidden="true" style={{ color: inverse ? "#66708A" : "#A7AEBB" }}>
+        <span
+          aria-hidden="true"
+          style={{ color: inverse ? "#66708A" : "#A7AEBB" }}
+        >
           ·
         </span>
         <a

--- a/src/router-core.ts
+++ b/src/router-core.ts
@@ -1,0 +1,56 @@
+import type { GrowthEventName } from "./growth/events";
+
+type EventValue = string | number | boolean | null;
+type EventProperties = Record<string, EventValue>;
+
+export type NavigationRuntime = {
+  pathname: string;
+  pushState: (path: string) => void;
+  broadcastLocationChange: () => void;
+  scrollToTop: () => void;
+  track: (name: GrowthEventName, properties?: EventProperties) => void;
+};
+
+export type NavigationResult = {
+  changed: boolean;
+  sourcePath: string;
+  destination: string;
+  growthEvent: GrowthEventName | null;
+};
+
+export function navigatePath(
+  destination: string,
+  runtime: NavigationRuntime,
+): NavigationResult {
+  const sourcePath = runtime.pathname;
+
+  if (destination === sourcePath) {
+    runtime.scrollToTop();
+    return {
+      changed: false,
+      sourcePath,
+      destination,
+      growthEvent: null,
+    };
+  }
+
+  let growthEvent: GrowthEventName | null = null;
+  if (destination === "/sandbox") {
+    growthEvent = "builder_start";
+  } else if (destination === "/contact") {
+    growthEvent = "commercial_contact_view";
+  }
+
+  if (growthEvent) runtime.track(growthEvent, { source_path: sourcePath });
+
+  runtime.pushState(destination);
+  runtime.broadcastLocationChange();
+  runtime.scrollToTop();
+
+  return {
+    changed: true,
+    sourcePath,
+    destination,
+    growthEvent,
+  };
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { trackGrowthEvent } from "./growth/events";
+import { navigatePath } from "./router-core";
 
 /** Minimal history-API router. Real URLs so every screen is linkable,
  * refreshable and back-button friendly — no framework needed.
@@ -19,21 +20,14 @@ export function usePath(): [string, (p: string) => void] {
   }, []);
 
   const go = useCallback((p: string) => {
-    if (p === window.location.pathname) {
-      window.scrollTo(0, 0);
-      return;
-    }
-
-    const sourcePath = window.location.pathname;
-    if (p === "/sandbox") {
-      trackGrowthEvent("builder_start", { source_path: sourcePath });
-    } else if (p === "/contact") {
-      trackGrowthEvent("commercial_contact_view", { source_path: sourcePath });
-    }
-
-    window.history.pushState({}, "", p);
-    window.dispatchEvent(new PopStateEvent("popstate"));
-    window.scrollTo(0, 0);
+    navigatePath(p, {
+      pathname: window.location.pathname,
+      pushState: (destination) => window.history.pushState({}, "", destination),
+      broadcastLocationChange: () =>
+        window.dispatchEvent(new PopStateEvent("popstate")),
+      scrollToTop: () => window.scrollTo(0, 0),
+      track: trackGrowthEvent,
+    });
   }, []);
 
   return [path, go];

--- a/workers/site/client-navigation.test.js
+++ b/workers/site/client-navigation.test.js
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { navigatePath } from "../../src/router-core.ts";
+
+function runtime(pathname = "/home") {
+  const actions = [];
+  const events = [];
+  return {
+    actions,
+    events,
+    value: {
+      pathname,
+      pushState: (path) => actions.push(["pushState", path]),
+      broadcastLocationChange: () => actions.push(["popstate"]),
+      scrollToTop: () => actions.push(["scroll", 0, 0]),
+      track: (name, properties = {}) => events.push({ name, properties }),
+    },
+  };
+}
+
+test("same-route navigation only resets scroll", () => {
+  const browser = runtime("/home");
+  const result = navigatePath("/home", browser.value);
+
+  assert.deepEqual(result, {
+    changed: false,
+    sourcePath: "/home",
+    destination: "/home",
+    growthEvent: null,
+  });
+  assert.deepEqual(browser.actions, [["scroll", 0, 0]]);
+  assert.deepEqual(browser.events, []);
+});
+
+test("cross-shell navigation pushes a real URL then broadcasts location change", () => {
+  const browser = runtime("/home");
+  const result = navigatePath("/cards", browser.value);
+
+  assert.equal(result.changed, true);
+  assert.equal(result.growthEvent, null);
+  assert.deepEqual(browser.actions, [
+    ["pushState", "/cards"],
+    ["popstate"],
+    ["scroll", 0, 0],
+  ]);
+  assert.deepEqual(browser.events, []);
+});
+
+test("Builder navigation attributes the source path before changing location", () => {
+  const browser = runtime("/blueprint");
+  const result = navigatePath("/sandbox", browser.value);
+
+  assert.equal(result.growthEvent, "builder_start");
+  assert.deepEqual(browser.events, [
+    {
+      name: "builder_start",
+      properties: { source_path: "/blueprint" },
+    },
+  ]);
+  assert.deepEqual(browser.actions, [
+    ["pushState", "/sandbox"],
+    ["popstate"],
+    ["scroll", 0, 0],
+  ]);
+});
+
+test("commercial navigation attributes the source path", () => {
+  const browser = runtime("/proof");
+  const result = navigatePath("/contact", browser.value);
+
+  assert.equal(result.growthEvent, "commercial_contact_view");
+  assert.deepEqual(browser.events, [
+    {
+      name: "commercial_contact_view",
+      properties: { source_path: "/proof" },
+    },
+  ]);
+});

--- a/workers/site/client-navigation.test.js
+++ b/workers/site/client-navigation.test.js
@@ -32,37 +32,43 @@ test("same-route navigation only resets scroll", () => {
   assert.deepEqual(browser.events, []);
 });
 
-test("cross-shell navigation pushes a real URL then broadcasts location change", () => {
-  const browser = runtime("/home");
-  const result = navigatePath("/cards", browser.value);
+test(
+  "cross-shell navigation pushes a real URL then broadcasts location change",
+  () => {
+    const browser = runtime("/home");
+    const result = navigatePath("/cards", browser.value);
 
-  assert.equal(result.changed, true);
-  assert.equal(result.growthEvent, null);
-  assert.deepEqual(browser.actions, [
-    ["pushState", "/cards"],
-    ["popstate"],
-    ["scroll", 0, 0],
-  ]);
-  assert.deepEqual(browser.events, []);
-});
+    assert.equal(result.changed, true);
+    assert.equal(result.growthEvent, null);
+    assert.deepEqual(browser.actions, [
+      ["pushState", "/cards"],
+      ["popstate"],
+      ["scroll", 0, 0],
+    ]);
+    assert.deepEqual(browser.events, []);
+  },
+);
 
-test("Builder navigation attributes the source path before changing location", () => {
-  const browser = runtime("/blueprint");
-  const result = navigatePath("/sandbox", browser.value);
+test(
+  "Builder navigation attributes the source path before changing location",
+  () => {
+    const browser = runtime("/blueprint");
+    const result = navigatePath("/sandbox", browser.value);
 
-  assert.equal(result.growthEvent, "builder_start");
-  assert.deepEqual(browser.events, [
-    {
-      name: "builder_start",
-      properties: { source_path: "/blueprint" },
-    },
-  ]);
-  assert.deepEqual(browser.actions, [
-    ["pushState", "/sandbox"],
-    ["popstate"],
-    ["scroll", 0, 0],
-  ]);
-});
+    assert.equal(result.growthEvent, "builder_start");
+    assert.deepEqual(browser.events, [
+      {
+        name: "builder_start",
+        properties: { source_path: "/blueprint" },
+      },
+    ]);
+    assert.deepEqual(browser.actions, [
+      ["pushState", "/sandbox"],
+      ["popstate"],
+      ["scroll", 0, 0],
+    ]);
+  },
+);
 
 test("commercial navigation attributes the source path", () => {
   const browser = runtime("/proof");


### PR DESCRIPTION
## Outcome

Close the highest-value frontend journey gap without adding a heavyweight browser dependency.

Phase 9 makes Blueballs' real client-navigation side effect independently executable/testable, keeps deep-link ownership protected by the existing edge route contract, and makes the v0.2 Blueprint/Proof surfaces discoverable from the full shared Blueballs lockup.

## Executable navigation contract

Extracts browser navigation into `src/router-core.ts`.

The contract now explicitly owns:
- same-route scroll reset without duplicate history entries;
- real History API path changes;
- location-change broadcast after `pushState` so every mounted route boundary updates;
- post-navigation scroll reset;
- Builder start attribution from the source path;
- commercial-contact attribution from the source path.

`usePath()` delegates all writes to that contract while retaining the existing popstate listener for browser back/forward navigation.

## Tests

Adds `workers/site/client-navigation.test.js` and runs it inside `pnpm test:workers`.

It proves:
- same-route behavior;
- cross-shell navigation ordering: `pushState → popstate → scroll`;
- Blueprint → Sandbox Builder attribution;
- Proof → commercial-contact attribution.

The existing edge/publication contracts continue to protect canonical deep links, refreshable routes, crawler metadata and route ownership.

## Product discoverability

The full shared Blueballs lockup now exposes compact **BLUEPRINTS · PROOF** shortcuts beside the brand.

This makes the two strongest v0.2 surfaces reachable from the main App shell and Contact shell without rewriting the large App monolith. Compact/footer lockups and `linked={false}` variants stay unchanged; Cards/Providers shells already expose Blueprints and Proof in their full navigation.

`check-site-routes` now protects both the executable router contract and Blueprint/Proof discoverability.

## Scope safety

No banking, ledger, FX, settlement, provider or Builder domain behavior changes. No new runtime or test dependency is added.

This is not claimed as full browser E2E. It moves the actual navigation side effects under executable regression tests using the repository's existing test toolchain; deployment/browser smoke remains a separate post-promotion check.