### PR TITLE
Stabilize header navigation and Cards Providers routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "preview:upload": "pnpm build && wrangler versions upload -c wrangler.jsonc",
     "test:api": "pnpm --dir apps/api test:ci",
     "test:fx": "node scripts/test-fx.mjs",
-    "test:workers": "pnpm --dir packages/sqlite-compat test:ci && node --test workers/site/edge-routing.test.js workers/site/growth-events.test.js workers/site/client-navigation.test.js workers/site/social-cards.test.js && vitest run --config vitest.config.mts && vitest run --config vitest.api.config.mts && vitest run --config vitest.fx.config.mts",
+    "test:workers": "pnpm --dir packages/sqlite-compat test:ci && node --test workers/site/edge-routing.test.js workers/site/growth-events.test.js workers/site/client-navigation.test.js workers/site/social-cards.test.js workers/site/header-navigation.test.js && vitest run --config vitest.config.mts && vitest run --config vitest.api.config.mts && vitest run --config vitest.fx.config.mts",
     "verify": "node scripts/release-proof.mjs",
     "verify:release": "node scripts/release-proof.mjs --require-clean --full",
     "verify:raw": "node scripts/verify.mjs",

--- a/src/Brand.tsx
+++ b/src/Brand.tsx
@@ -54,7 +54,7 @@ export function BrandLockup({
     return <span className="bb-brand-lockup">{contents}</span>;
   }
 
-  const home = (
+  return (
     <a
       className="bb-brand-lockup"
       href="/home"
@@ -63,60 +63,5 @@ export function BrandLockup({
     >
       {contents}
     </a>
-  );
-
-  if (compact) return home;
-
-  return (
-    <span
-      className="bb-brand-cluster"
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        gap: 11,
-        flexWrap: "wrap",
-      }}
-    >
-      {home}
-      <span
-        aria-label="Blueballs product shortcuts"
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: 6,
-          paddingLeft: 11,
-          borderLeft: `1px solid ${inverse ? "#34416A" : "#D7DBE4"}`,
-          fontFamily: "'IBM Plex Mono', monospace",
-          fontSize: 8.5,
-          letterSpacing: "0.07em",
-          whiteSpace: "nowrap",
-        }}
-      >
-        <a
-          href="/blueprint"
-          style={{
-            color: inverse ? "#C5CAD7" : "#5B6376",
-            textDecoration: "none",
-          }}
-        >
-          BLUEPRINTS
-        </a>
-        <span
-          aria-hidden="true"
-          style={{ color: inverse ? "#66708A" : "#A7AEBB" }}
-        >
-          ·
-        </span>
-        <a
-          href="/proof"
-          style={{
-            color: inverse ? "#C5CAD7" : "#5B6376",
-            textDecoration: "none",
-          }}
-        >
-          PROOF
-        </a>
-      </span>
-    </span>
   );
 }

--- a/src/header-stability.css
+++ b/src/header-stability.css
@@ -1,0 +1,124 @@
+/* Header stability contract.
+ *
+ * The public header uses a 1200px shell. Desktop navigation must never wrap
+ * inside that shell: once space becomes tight we switch to the existing mobile
+ * menu as one deliberate state change instead of letting individual buttons
+ * jump between rows.
+ */
+
+@media (min-width: 1241px) {
+  .bb-site-header {
+    flex-wrap: nowrap !important;
+  }
+
+  .bb-site-brand {
+    min-width: max-content;
+    flex: 0 0 auto !important;
+  }
+
+  .bb-site-nav-desktop {
+    flex-wrap: nowrap !important;
+    white-space: nowrap;
+  }
+}
+
+@media (max-width: 1240px) {
+  .bb-site-header {
+    position: sticky;
+    top: 8px;
+    z-index: 40;
+    flex-wrap: wrap !important;
+    gap: 10px !important;
+    padding: 10px 12px !important;
+    box-shadow: 0 10px 30px rgba(7, 20, 79, 0.08);
+  }
+
+  .bb-site-brand {
+    min-width: 0;
+    flex: 1 1 auto !important;
+  }
+
+  .bb-site-brand-tag {
+    display: none;
+  }
+
+  .bb-site-nav-desktop,
+  .bb-site-cta {
+    display: none !important;
+  }
+
+  .bb-mobile-menu-button {
+    display: inline-flex;
+    width: 44px;
+    height: 44px;
+    flex: 0 0 44px;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 5px;
+    padding: 0;
+    border: 1px solid #d7dbe4;
+    border-radius: 11px;
+    background: #f7f8fb;
+    cursor: pointer;
+  }
+
+  .bb-mobile-menu-button span {
+    display: block;
+    width: 19px;
+    height: 2px;
+    border-radius: 99px;
+    background: #07144f;
+    transition:
+      transform 0.18s ease,
+      opacity 0.18s ease;
+  }
+
+  .bb-mobile-menu-button[aria-expanded="true"] span:nth-child(1) {
+    transform: translateY(7px) rotate(45deg);
+  }
+
+  .bb-mobile-menu-button[aria-expanded="true"] span:nth-child(2) {
+    opacity: 0;
+  }
+
+  .bb-mobile-menu-button[aria-expanded="true"] span:nth-child(3) {
+    transform: translateY(-7px) rotate(-45deg);
+  }
+
+  .bb-mobile-nav {
+    display: grid;
+    width: 100%;
+    flex: 1 0 100%;
+    grid-template-columns: 1fr 1fr;
+    gap: 7px;
+    padding-top: 10px;
+    border-top: 1px solid #e7eaf0;
+  }
+
+  .bb-mobile-nav button {
+    min-height: 44px;
+    padding: 10px 12px;
+    border: 1px solid #e1e5ed;
+    border-radius: 10px;
+    background: #f7f8fb;
+    color: #4e576b;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .bb-mobile-nav button[aria-current="page"] {
+    border-color: #c9d9ff;
+    background: #edf3ff;
+    color: #07144f;
+    font-weight: 600;
+  }
+
+  .bb-mobile-nav .bb-mobile-nav-primary {
+    grid-column: 1 / -1;
+    border-color: #07144f;
+    background: #07144f;
+    color: #ffffff;
+    text-align: center;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import SiteRoot from "./SiteRoot";
 import "./index.css";
+import "./header-stability.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/workers/site/header-navigation.test.js
+++ b/workers/site/header-navigation.test.js
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const app = readFileSync(new URL("../../src/App.tsx", import.meta.url), "utf8");
+const siteRoot = readFileSync(
+  new URL("../../src/SiteRoot.tsx", import.meta.url),
+  "utf8",
+);
+const brand = readFileSync(new URL("../../src/Brand.tsx", import.meta.url), "utf8");
+const headerCss = readFileSync(
+  new URL("../../src/header-stability.css", import.meta.url),
+  "utf8",
+);
+const main = readFileSync(new URL("../../src/main.tsx", import.meta.url), "utf8");
+
+test("Cards and Providers in the main shell use the shared browser router", () => {
+  assert.match(
+    app,
+    /const selectDirectory = \(nextPath: "\/cards" \| "\/ecosystem"\) => \{[\s\S]*?go\(nextPath\);[\s\S]*?\};/,
+  );
+  assert.match(app, /selectDirectory\("\/cards"\)/);
+  assert.match(app, /selectDirectory\("\/ecosystem"\)/);
+});
+
+test("Cards and Providers keep one stable order in the directory shell", () => {
+  assert.match(
+    siteRoot,
+    /\["Developers", "\/developers"\],[\s\S]*?\["Cards", "\/cards"\],[\s\S]*?\["Providers", "\/ecosystem"\]/,
+  );
+  assert.match(
+    siteRoot,
+    /onClick=\{\(\) => go\(path\)\}/,
+    "directory navigation must route every item through the same go() function",
+  );
+});
+
+test("the shared brand is brand-only and cannot consume nav width with product links", () => {
+  assert.match(brand, /href="\/home"/);
+  assert.doesNotMatch(brand, /href="\/blueprint"/);
+  assert.doesNotMatch(brand, /href="\/proof"/);
+  assert.doesNotMatch(brand, /bb-brand-cluster/);
+});
+
+test("desktop headers cannot wrap and collapse deliberately before space gets tight", () => {
+  assert.match(main, /import "\.\/header-stability\.css"/);
+  assert.match(headerCss, /@media \(min-width: 1241px\)/);
+  assert.match(
+    headerCss,
+    /\.bb-site-header \{[\s\S]*?flex-wrap: nowrap !important;/,
+  );
+  assert.match(
+    headerCss,
+    /\.bb-site-nav-desktop \{[\s\S]*?flex-wrap: nowrap !important;/,
+  );
+  assert.match(headerCss, /@media \(max-width: 1240px\)/);
+  assert.match(
+    headerCss,
+    /\.bb-site-nav-desktop,[\s\S]*?\.bb-site-cta \{[\s\S]*?display: none !important;/,
+  );
+  assert.match(
+    headerCss,
+    /\.bb-mobile-menu-button \{[\s\S]*?display: inline-flex;/,
+  );
+});


### PR DESCRIPTION
## Outcome

Fix the public-header regression where navigation controls could wrap/reflow and make Cards / Providers appear to move or behave inconsistently.

## Root cause

Phase 9 expanded the shared `BrandLockup` with `BLUEPRINTS · PROOF` shortcuts while the 1200px header shell and desktop nav both still allowed flex wrapping. On the main shell, Cards and Providers are separate route buttons appended after the page nav array. At tight desktop widths this created unstable wrapping/reflow around the controls.

## Fix

### Brand is brand-only again
- removes product shortcuts from `BrandLockup`;
- keeps the brand width deterministic across public shells;
- product navigation remains in actual navigation surfaces rather than inside the logo/brand control.

### One deliberate responsive transition
Adds `header-stability.css`:
- desktop headers (`>=1241px`) are hard-locked to one row;
- desktop nav itself cannot wrap;
- below 1241px the header switches to the existing mobile menu before controls run out of room;
- desktop nav + CTA hide together;
- the hamburger/mobile grid takes over as one coherent layout state.

This prevents individual buttons from jumping rows or changing apparent position.

### Cards / Providers regression coverage
Adds `header-navigation.test.js` to the existing Worker test command. It asserts:
- main-shell Cards and Providers both delegate to the shared browser router;
- directory-shell Cards and Providers stay in one fixed order;
- directory navigation routes every item through the same `go()` function;
- the brand cannot silently regain Blueprint/Proof product links;
- desktop header/nav wrapping cannot return;
- the medium-width mobile transition remains in place.

## Scope safety

No banking, ledger, FX, settlement, provider ranking, Builder or commercial behavior changes. No dependency changes. This is a focused public-navigation/layout repair.